### PR TITLE
Trust all certificate policy added

### DIFF
--- a/MinecraftClient/MinecraftCom.cs
+++ b/MinecraftClient/MinecraftCom.cs
@@ -1,9 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Net;
 using System.Net.Sockets;
+using System.Security.Cryptography.X509Certificates;
 
 namespace MinecraftClient
 {


### PR DESCRIPTION
I'm working to get this Linux compatible.  Mono does not trust any certificates by default, so I've added a certificate policy that bypasses certificate checking.  This should be treated as a temporary fix.
