### PR TITLE
Add protocol version 78 (1.6.4) to the list of supported versions.

### DIFF
--- a/MinecraftClient/Program.cs
+++ b/MinecraftClient/Program.cs
@@ -211,7 +211,7 @@ namespace MinecraftClient
                 if (MinecraftCom.GetServerInfo(Settings.ServerIP, ref protocolversion, ref version))
                 {
                     //Supported protocol version ?
-                    int[] supportedVersions = { 51, 60, 61, 72, 73, 74 };
+                    int[] supportedVersions = { 51, 60, 61, 72, 73, 74, 78 };
                     if (Array.IndexOf(supportedVersions, protocolversion) > -1)
                     {
                         //Minecraft 1.6+ ? Load translations


### PR DESCRIPTION
The only thing changed between this one and the PR that I had made was that we are using the Indev branch now. I have confirmed that the client works fine with and without authentication, and over the internet.
