### PR TITLE
Indev

### DIFF
--- a/MinecraftClient/McTcpClient.cs
+++ b/MinecraftClient/McTcpClient.cs
@@ -53,7 +53,7 @@ namespace MinecraftClient
         /// <param name="port">The server port to use</param>
         /// <param name="protocolversion">Minecraft protocol version to use</param>
 
-        public McTcpClient(string username, string uuid, string sessionID, int protocolversion, string server_ip, int port)
+        public McTcpClient(string username, string uuid, string sessionID, int protocolversion, string server_ip, ushort port)
         {
             StartClient(username, uuid, sessionID, server_ip, port, protocolversion, false, "");
         }
@@ -69,7 +69,7 @@ namespace MinecraftClient
         /// <param name="protocolversion">Minecraft protocol version to use</param>
         /// <param name="command">The text or command to send.</param>
 
-        public McTcpClient(string username, string uuid, string sessionID, string server_ip, int port, int protocolversion, string command)
+        public McTcpClient(string username, string uuid, string sessionID, string server_ip, ushort port, int protocolversion, string command)
         {
             StartClient(username, uuid, sessionID, server_ip, port, protocolversion, true, command);
         }
@@ -86,7 +86,7 @@ namespace MinecraftClient
         /// <param name="singlecommand">If set to true, the client will send a single command and then disconnect from the server</param>
         /// <param name="command">The text or command to send. Will only be sent if singlecommand is set to true.</param>
 
-        private void StartClient(string user, string uuid, string sessionID, string server_ip, int port, int protocolversion, bool singlecommand, string command)
+        private void StartClient(string user, string uuid, string sessionID, string server_ip, ushort port, int protocolversion, bool singlecommand, string command)
         {
             this.sessionid = sessionID;
             this.uuid = uuid;

--- a/MinecraftClient/Protocol/ProtocolHandler.cs
+++ b/MinecraftClient/Protocol/ProtocolHandler.cs
@@ -23,7 +23,7 @@ namespace MinecraftClient.Protocol
         /// <param name="protocolversion">Will contain protocol version, if ping successful</param>
         /// <returns>TRUE if ping was successful</returns>
 
-        public static bool GetServerInfo(string serverIP, int serverPort, ref int protocolversion)
+        public static bool GetServerInfo(string serverIP, ushort serverPort, ref int protocolversion)
         {
             try
             {

--- a/MinecraftClient/Settings.cs
+++ b/MinecraftClient/Settings.cs
@@ -20,7 +20,7 @@ namespace MinecraftClient
         public static string Username = "";
         public static string Password = "";
         public static string ServerIP = "";
-        public static int ServerPort = 25565;
+        public static ushort ServerPort = 25565;
         public static string ServerVersion  = "";
         public static string SingleCommand = "";
         public static string ConsoleTitle = "";
@@ -90,7 +90,7 @@ namespace MinecraftClient
         //Custom app variables and Minecraft accounts
         private static Dictionary<string, string> AppVars = new Dictionary<string, string>();
         private static Dictionary<string, KeyValuePair<string, string>> Accounts = new Dictionary<string, KeyValuePair<string, string>>();
-        private static Dictionary<string, KeyValuePair<string, int>> Servers = new Dictionary<string, KeyValuePair<string, int>>();
+        private static Dictionary<string, KeyValuePair<string, ushort>> Servers = new Dictionary<string, KeyValuePair<string, ushort>>();
 
         private enum ParseMode { Default, Main, AppVars, Proxy, AntiAFK, Hangman, Alerts, ChatLog, AutoRelog, ScriptScheduler, RemoteControl };
 
@@ -186,7 +186,7 @@ namespace MinecraftClient
                                                     {
                                                         //Backup current server info
                                                         string server_host_temp = ServerIP;
-                                                        int server_port_temp = ServerPort;
+                                                        ushort server_port_temp = ServerPort;
 
                                                         foreach (string server_line in File.ReadAllLines(argValue))
                                                         {
@@ -198,7 +198,7 @@ namespace MinecraftClient
                                                                 && !server_data[0].Contains('.')
                                                                 && setServerIP(server_data[1]))
                                                                 Servers[server_data[0]]
-                                                                    = new KeyValuePair<string, int>(ServerIP, ServerPort);
+                                                                    = new KeyValuePair<string, ushort>(ServerIP, ServerPort);
                                                         }
                                                         
                                                         //Restore current server info
@@ -432,13 +432,13 @@ namespace MinecraftClient
             server = server.ToLower();
             string[] sip = server.Split(':');
             string host = sip[0];
-            short port = 25565;
+            ushort port = 25565;
             
             if (sip.Length > 1)
             {
                 try
                 {
-                    port = Convert.ToInt16(sip[1]);
+                    port = Convert.ToUInt16(sip[1]);
                 }
                 catch (FormatException) { return false; }
             }


### PR DESCRIPTION
The fix you made for the overflow exception did not quite work as you were still using Convert.ToInt16 which would still overflow on high ports.  I've now merged my changes on to the Indev branch and tested it and it seems to work ok.  I think the choice of ushort is better because the tcp rfc specifies that a port is a maximum of 16 bits long and you can't have negative port numbers. 

Console Client for MC 1.4.6 to 1.8.1 - v1.8.0 - By ORelio & Contributors
Username : xxxxxxxxx
Password : <******>                                                                                                                                                                                                Connecting to Minecraft.net...
Success. (session ID: xxxxxxxxxxx)
Server IP : xxxxxxxxx.com:40003
Retrieving Server Info...
Downloading 'en_GB.lang' from Mojang servers...
Done. File saved as 'lang/en_GB.lang'
Translations file loaded.
Version is supported.
Logging in...
Crypto keys & hash generated.
Checking Session...
Server was successfully joined.
Type '/quit' to leave the server.

> meep
> <lokulin> meep 
> <okstyr> beep 
