### PR TITLE
Update RemoteControl.cs

### DIFF
--- a/MinecraftClient/ChatBots/RemoteControl.cs
+++ b/MinecraftClient/ChatBots/RemoteControl.cs
@@ -15,7 +15,7 @@ namespace MinecraftClient.ChatBots
         {
             text = getVerbatim(text);
             string command = "", sender = "";
-            if (isPrivateMessage(text, ref command, ref sender) && Settings.Bots_Owners.Contains(sender.ToLower()))
+            if (isPrivateMessage(text, ref command, ref sender) && Settings.Bots_Owners.Contains(sender.ToLower().Replace(" ","")))
             {
                 string response = "";
                 performInternalCommand(command, ref response);
@@ -26,7 +26,7 @@ namespace MinecraftClient.ChatBots
             }
             else if (Settings.RemoteCtrl_AutoTpaccept
                 && isTeleportRequest(text, ref sender)
-                && (Settings.RemoteCtrl_AutoTpaccept_Everyone || Settings.Bots_Owners.Contains(sender.ToLower())))
+                && (Settings.RemoteCtrl_AutoTpaccept_Everyone || Settings.Bots_Owners.Contains(sender.ToLower().Replace(" ",""))))
             {
                 SendText("/tpaccept");
             }


### PR DESCRIPTION
when you make the botowners you remove the spaces so i think you have to remove spaces from here too, then name like "Paladin: medxo" will work too