### PR TITLE
Add option to disable background recolors.

### DIFF
--- a/MinecraftClient/ChatBots/Alerts.cs
+++ b/MinecraftClient/ChatBots/Alerts.cs
@@ -88,8 +88,14 @@ namespace MinecraftClient.ChatBots
                                 ConsoleIO.Write(splitted[i]);
                             }
                         }
-
-                        Console.BackgroundColor = ConsoleColor.Black;
+                        if(!Settings.useDefaultBackground)
+                        {
+                            Console.BackgroundColor = ConsoleColor.Black;
+                        }
+                        else 
+                        {
+                            Console.ResetColor();
+                        }                        
                         Console.ForegroundColor = ConsoleColor.Gray;
                         ConsoleIO.Write('\n');
                     }

--- a/MinecraftClient/ConsoleIO.cs
+++ b/MinecraftClient/ConsoleIO.cs
@@ -209,7 +209,9 @@ namespace MinecraftClient
                 else Console.Write("\b \b");
                 Console.Write(text);
                 Console.ForegroundColor = ConsoleColor.Gray;
-                Console.BackgroundColor = ConsoleColor.Black;
+                if(!Settings.useDefaultBackground) {
+                    Console.BackgroundColor = ConsoleColor.Black;
+                }   
                 buffer = buf;
                 buffer2 = buf2;
                 Console.Write(">" + buffer);
@@ -219,7 +221,9 @@ namespace MinecraftClient
                     for (int i = 0; i < buffer2.Length; i++) { GoBack(); }
                 }
                 Console.ForegroundColor = fore;
-                Console.BackgroundColor = back;
+                if(!Settings.useDefaultBackground) {
+                    Console.BackgroundColor = back;
+                }
             }
             else Console.Write(text);
             writing_lock = false;

--- a/MinecraftClient/Settings.cs
+++ b/MinecraftClient/Settings.cs
@@ -44,6 +44,7 @@ namespace MinecraftClient
         public static char internalCmdChar = '/';
         public static bool playerHeadAsIcon = false;
         public static string chatbotLogFile = "";
+        public static bool useDefaultBackground = false;
 
         //AntiAFK Settings
         public static bool AntiAFK_Enabled = false;
@@ -152,6 +153,7 @@ namespace MinecraftClient
                                                 case "playerheadicon": playerHeadAsIcon = str2bool(argValue); break;
                                                 case "chatbotlogfile": chatbotLogFile = argValue; break;
                                                 case "mcversion": ServerVersion = argValue; break;
+                                                case "defaultbackground": useDefaultBackground = str2bool(argValue); break;
 
                                                 case "botowners":
                                                     Bots_Owners.Clear();
@@ -351,6 +353,7 @@ namespace MinecraftClient
                 + "playerheadicon=true\r\n"
                 + "exitonfailure=false\r\n"
                 + "timestamps=false\r\n"
+                + "defaultbackground=false\r\n"
                 + "\r\n"
                 + "[AppVars]\r\n"
                 + "#yourvar=yourvalue\r\n"


### PR DESCRIPTION
The console puts out this annoying black background, which screws with my terminal (I'm on OSX via mono). This PR makes this background opt-out. This PR has not been tested with .NET tools, but mono should be a sufficient facsimile.