### PR TITLE
Fixed issues with passwords containing unicode special characters, such as "Ð".

### DIFF
--- a/MinecraftClient/ConsoleIO.cs
+++ b/MinecraftClient/ConsoleIO.cs
@@ -45,22 +45,18 @@ namespace MinecraftClient
 
         public static string ReadPassword()
         {
-            string password = "";
-            ConsoleKeyInfo k = new ConsoleKeyInfo();
-            while (k.Key != ConsoleKey.Enter)
+            StringBuilder password = new StringBuilder();
+
+            ConsoleKeyInfo k;
+            while ((k = Console.ReadKey(true)).Key != ConsoleKey.Enter)
             {
-                k = Console.ReadKey(true);
                 switch (k.Key)
                 {
-                    case ConsoleKey.Enter:
-                        Console.Write('\n');
-                        return password;
-
                     case ConsoleKey.Backspace:
                         if (password.Length > 0)
                         {
                             Console.Write("\b \b");
-                            password = password.Substring(0, password.Length - 1);
+                            password.Remove(password.Length - 1, 1);
                         }
                         break;
 
@@ -79,12 +75,14 @@ namespace MinecraftClient
                         if (k.KeyChar != 0)
                         {
                             Console.Write('*');
-                            password += k.KeyChar;
+                            password.Append(k.KeyChar);
                         }
                         break;
                 }
             }
-            return password;
+
+            Console.WriteLine();
+            return password.ToString();
         }
 
         /// <summary>

--- a/MinecraftClient/Protocol/ProtocolHandler.cs
+++ b/MinecraftClient/Protocol/ProtocolHandler.cs
@@ -285,16 +285,18 @@ namespace MinecraftClient.Protocol
             StringBuilder result = new StringBuilder();
             foreach (char c in text)
             {
-                if (char.IsLetterOrDigit(c))
+                if ((c >= '0' && c <= '9') ||
+                    (c >= 'a' && c <= 'z') ||
+                    (c >= 'A' && c <= 'Z'))
                 {
                     result.Append(c);
                 }
                 else
                 {
-                    result.Append("\\u");
-                    result.Append(((int)c).ToString("x4"));
+                    result.AppendFormat(@"\u{0:x4}", (int)c);
                 }
             }
+
             return result.ToString();
         }
     }


### PR DESCRIPTION
This fixes [the issue that JarJpg was having](http://www.minecraftforum.net/forums/mapping-and-modding/minecraft-tools/1263927-win-mac-linux-minecraft-console-client-1-8-3?comment=1409) with logging in due to their password containing "Ð".

The main fix is the change to ProtocolHandler's jsonEncode method.  Previously,
it used ['char.IsLetterOrDigit'](https://msdn.microsoft.com/en-us/library/cay4xx2f(v=vs.110).aspx) to see if it needed to be escaped, but "Ð" is a
letter and still needs to be escaped.  The fix is to simply check if it's in
the right range.

Previously, the password `TestÐ123` would be sent as `TestÐ123`, which Mojang's servers would reject.  Now, it is sent as `Test\u00D0123`, which is the correct thing.  (Tested with an alt account).  

There's also some changes to those methods for performance and clarity reasons.
Most of this is using a [`StringBuilder`](https://msdn.microsoft.com/en-us/library/system.text.stringbuilder(v=vs.110).aspx) rather than appending to the string.  Not
too important, but it makes things clearer.

You mentioned [here](http://www.minecraftforum.net/forums/mapping-and-modding/minecraft-tools/1263927-win-mac-linux-minecraft-console-client-1-8-3?comment=1415) that the keys were named OemSomething.  That's true, but it seems like the [`KeyChar`](https://msdn.microsoft.com/en-us/library/system.ConsoleKeyInfo.keychar(v=vs.110).aspx) property gets the right symbol automatically, so we fortunately don't have to deal with that.