### PR TITLE
Proxy work-around / Fix.

### DIFF
--- a/MinecraftClient/McTcpClient.cs
+++ b/MinecraftClient/McTcpClient.cs
@@ -111,7 +111,14 @@ namespace MinecraftClient
 
             try
             {
-                client = ProxyHandler.newTcpClient(host, port);
+                if (Settings.LoginOnlyProxy = true)
+                {
+                    client = new TcpClient(host, port);
+                }
+                else
+                {
+                    client = ProxyHandler.newTcpClient(host, port);
+                }
                 client.ReceiveBufferSize = 1024 * 1024;
                 handler = Protocol.ProtocolHandler.getProtocolHandler(client, protocolversion, this);
                 Console.WriteLine("Version is supported.\nLogging in...");

--- a/MinecraftClient/McTcpClient.cs
+++ b/MinecraftClient/McTcpClient.cs
@@ -111,7 +111,7 @@ namespace MinecraftClient
 
             try
             {
-                if (Settings.LoginOnlyProxy = true)
+                if (Settings.OnlyForLogin)
                 {
                     client = new TcpClient(host, port);
                 }

--- a/MinecraftClient/Settings.cs
+++ b/MinecraftClient/Settings.cs
@@ -32,6 +32,7 @@ namespace MinecraftClient
         public static Proxy.ProxyHandler.Type proxyType = Proxy.ProxyHandler.Type.HTTP;
         public static string ProxyUsername = "";
         public static string ProxyPassword = "";
+        public static bool LoginOnlyProxy = false;
 
         //Other Settings
         public static string TranslationsFile_FromMCDir = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + @"\.minecraft\assets\objects\9e\9e2fdc43fc1c7024ff5922b998fadb2971a64ee0"; //MC 1.7.4 en_GB.lang
@@ -290,7 +291,6 @@ namespace MinecraftClient
                                                 case "enabled": RemoteCtrl_Enabled = str2bool(argValue); break;
                                                 case "autotpaccept": RemoteCtrl_AutoTpaccept = str2bool(argValue); break;
                                                 case "tpaccepteveryone": RemoteCtrl_AutoTpaccept_Everyone = str2bool(argValue); break;
-                                                case "herochatmessagesenabled": Hero_Chat_Messages_Enabled = str2bool(argValue); break;
                                             }
                                             break;
 
@@ -308,6 +308,7 @@ namespace MinecraftClient
                                             switch (argName.ToLower())
                                             {
                                                 case "enabled": ProxyEnabled = str2bool(argValue); break;
+                                                case "loginonlyproxy": LoginOnlyProxy = str2bool(argValue); break;
                                                 case "type":
                                                     argValue = argValue.ToLower();
                                                     if (argValue == "http") { proxyType = Proxy.ProxyHandler.Type.HTTP; }
@@ -402,6 +403,7 @@ namespace MinecraftClient
                 + "server=0.0.0.0:0000\r\n"
                 + "username=\r\n"
                 + "password=\r\n"
+                + "loginonlyproxy=false # Change this to \"true\" if you only want to use a proxy for login."
                 + "\r\n"
                 + "#Bot Settings\r\n"
                 + "\r\n"

--- a/MinecraftClient/Settings.cs
+++ b/MinecraftClient/Settings.cs
@@ -32,7 +32,7 @@ namespace MinecraftClient
         public static Proxy.ProxyHandler.Type proxyType = Proxy.ProxyHandler.Type.HTTP;
         public static string ProxyUsername = "";
         public static string ProxyPassword = "";
-        public static bool LoginOnlyProxy = false;
+        public static bool OnlyForLogin = false;
 
         //Other Settings
         public static string TranslationsFile_FromMCDir = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + @"\.minecraft\assets\objects\9e\9e2fdc43fc1c7024ff5922b998fadb2971a64ee0"; //MC 1.7.4 en_GB.lang
@@ -308,7 +308,7 @@ namespace MinecraftClient
                                             switch (argName.ToLower())
                                             {
                                                 case "enabled": ProxyEnabled = str2bool(argValue); break;
-                                                case "loginonlyproxy": LoginOnlyProxy = str2bool(argValue); break;
+                                                case "onlyforlogin": OnlyForLogin = str2bool(argValue); break;
                                                 case "type":
                                                     argValue = argValue.ToLower();
                                                     if (argValue == "http") { proxyType = Proxy.ProxyHandler.Type.HTTP; }
@@ -403,7 +403,7 @@ namespace MinecraftClient
                 + "server=0.0.0.0:0000\r\n"
                 + "username=\r\n"
                 + "password=\r\n"
-                + "loginonlyproxy=false # Change this to \"true\" if you only want to use a proxy for login."
+                + "onlyforlogin=false # Change this to \"true\" if you only want to use a proxy for login."
                 + "\r\n"
                 + "#Bot Settings\r\n"
                 + "\r\n"


### PR DESCRIPTION
Added 'loginonlyproxy' option with true / false boolean options.
on 'true' only the minecraft login is redirected to the proxy.
Otherwise both the login and the server connection are routed though the
chosen proxy.

This was mentioned by me on Minecraftforums so I eventually pulled it off myself.  Not sure if it works 100% properly BUT it does work on my test box.  True works and false does nothing new.
Provides a semi-workaround to issues #89 and #80 on ORelio/Indev