### PR TITLE
Add forge (1.8 and 1.7.10) support

### DIFF
--- a/MinecraftClient/McTcpClient.cs
+++ b/MinecraftClient/McTcpClient.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Net;
 using MinecraftClient.Protocol;
 using MinecraftClient.Proxy;
+using MinecraftClient.Protocol.Handlers.Forge;
 
 namespace MinecraftClient
 {
@@ -54,9 +55,9 @@ namespace MinecraftClient
         /// <param name="port">The server port to use</param>
         /// <param name="protocolversion">Minecraft protocol version to use</param>
 
-        public McTcpClient(string username, string uuid, string sessionID, int protocolversion, string server_ip, ushort port)
+        public McTcpClient(string username, string uuid, string sessionID, int protocolversion, ForgeInfo forgeInfo, string server_ip, ushort port)
         {
-            StartClient(username, uuid, sessionID, server_ip, port, protocolversion, false, "");
+            StartClient(username, uuid, sessionID, server_ip, port, protocolversion, forgeInfo, false, "");
         }
 
         /// <summary>
@@ -70,9 +71,9 @@ namespace MinecraftClient
         /// <param name="protocolversion">Minecraft protocol version to use</param>
         /// <param name="command">The text or command to send.</param>
 
-        public McTcpClient(string username, string uuid, string sessionID, string server_ip, ushort port, int protocolversion, string command)
+        public McTcpClient(string username, string uuid, string sessionID, string server_ip, ushort port, int protocolversion, ForgeInfo forgeInfo, string command)
         {
-            StartClient(username, uuid, sessionID, server_ip, port, protocolversion, true, command);
+            StartClient(username, uuid, sessionID, server_ip, port, protocolversion, forgeInfo, true, command);
         }
 
         /// <summary>
@@ -87,7 +88,7 @@ namespace MinecraftClient
         /// <param name="singlecommand">If set to true, the client will send a single command and then disconnect from the server</param>
         /// <param name="command">The text or command to send. Will only be sent if singlecommand is set to true.</param>
 
-        private void StartClient(string user, string uuid, string sessionID, string server_ip, ushort port, int protocolversion, bool singlecommand, string command)
+        private void StartClient(string user, string uuid, string sessionID, string server_ip, ushort port, int protocolversion, ForgeInfo forgeInfo, bool singlecommand, string command)
         {
             bool retry = false;
             this.sessionid = sessionID;
@@ -113,7 +114,7 @@ namespace MinecraftClient
             {
                 client = ProxyHandler.newTcpClient(host, port);
                 client.ReceiveBufferSize = 1024 * 1024;
-                handler = Protocol.ProtocolHandler.getProtocolHandler(client, protocolversion, this);
+                handler = Protocol.ProtocolHandler.getProtocolHandler(client, protocolversion, forgeInfo, this);
                 Console.WriteLine("Version is supported.\nLogging in...");
 
                 try

--- a/MinecraftClient/MinecraftClient.csproj
+++ b/MinecraftClient/MinecraftClient.csproj
@@ -114,6 +114,8 @@
     <Compile Include="Crypto\Streams\RegularAesStream.cs" />
     <Compile Include="Crypto\CryptoHandler.cs" />
     <Compile Include="CSharpRunner.cs" />
+    <Compile Include="Protocol\Handlers\Forge\FMLHandshakeClientState.cs" />
+    <Compile Include="Protocol\Handlers\Forge\FMLHandshakeDiscriminator.cs" />
     <Compile Include="Protocol\Handlers\Forge\ForgeInfo.cs" />
     <Compile Include="Protocol\Handlers\Compression\CRC32.cs" />
     <Compile Include="Protocol\Handlers\Compression\Deflate.cs" />

--- a/MinecraftClient/MinecraftClient.csproj
+++ b/MinecraftClient/MinecraftClient.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Crypto\Streams\RegularAesStream.cs" />
     <Compile Include="Crypto\CryptoHandler.cs" />
     <Compile Include="CSharpRunner.cs" />
+    <Compile Include="Protocol\Handlers\Forge\ForgeInfo.cs" />
     <Compile Include="Protocol\Handlers\Compression\CRC32.cs" />
     <Compile Include="Protocol\Handlers\Compression\Deflate.cs" />
     <Compile Include="Protocol\Handlers\Compression\GZipStream.cs" />

--- a/MinecraftClient/Program.cs
+++ b/MinecraftClient/Program.cs
@@ -5,6 +5,7 @@ using System.Text;
 using MinecraftClient.Protocol;
 using System.Reflection;
 using System.Threading;
+using MinecraftClient.Protocol.Handlers.Forge;
 
 namespace MinecraftClient
 {
@@ -145,6 +146,7 @@ namespace MinecraftClient
 
                 //Get server version
                 int protocolversion = 0;
+                ForgeInfo forgeInfo = null;
 
                 if (Settings.ServerVersion != "" && Settings.ServerVersion.ToLower() != "auto")
                 {
@@ -166,7 +168,7 @@ namespace MinecraftClient
                 if (protocolversion == 0)
                 {
                     Console.WriteLine("Retrieving Server Info...");
-                    if (!ProtocolHandler.GetServerInfo(Settings.ServerIP, Settings.ServerPort, ref protocolversion))
+                    if (!ProtocolHandler.GetServerInfo(Settings.ServerIP, Settings.ServerPort, ref protocolversion, ref forgeInfo))
                     {
                         HandleFailure("Failed to ping this IP.", true, ChatBots.AutoRelog.DisconnectReason.ConnectionLost);
                         return;
@@ -180,9 +182,9 @@ namespace MinecraftClient
                         //Start the main TCP client
                         if (Settings.SingleCommand != "")
                         {
-                            Client = new McTcpClient(Settings.Username, UUID, sessionID, Settings.ServerIP, Settings.ServerPort, protocolversion, Settings.SingleCommand);
+                            Client = new McTcpClient(Settings.Username, UUID, sessionID, Settings.ServerIP, Settings.ServerPort, protocolversion, forgeInfo, Settings.SingleCommand);
                         }
-                        else Client = new McTcpClient(Settings.Username, UUID, sessionID, protocolversion, Settings.ServerIP, Settings.ServerPort);
+                        else Client = new McTcpClient(Settings.Username, UUID, sessionID, protocolversion, forgeInfo, Settings.ServerIP, Settings.ServerPort);
 
                         //Update console title
                         if (Settings.ConsoleTitle != "")

--- a/MinecraftClient/Protocol/Handlers/Forge/FMLHandshakeClientState.cs
+++ b/MinecraftClient/Protocol/Handlers/Forge/FMLHandshakeClientState.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MinecraftClient.Protocol.Handlers.Forge
+{
+    /// <summary>
+    /// Copy of the forge enum for client states.
+    /// https://github.com/MinecraftForge/MinecraftForge/blob/ebe9b6d4cbc4a5281c386994f1fbda04df5d2e1f/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeClientState.java
+    /// </summary>
+    enum FMLHandshakeClientState : byte
+    {
+        START,
+        HELLO,
+        WAITINGSERVERDATA,
+        WAITINGSERVERCOMPLETE,
+        PENDINGCOMPLETE,
+        COMPLETE,
+        DONE,
+        ERROR
+    }
+}

--- a/MinecraftClient/Protocol/Handlers/Forge/FMLHandshakeDiscriminator.cs
+++ b/MinecraftClient/Protocol/Handlers/Forge/FMLHandshakeDiscriminator.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MinecraftClient.Protocol.Handlers.Forge
+{
+    /// <summary>
+    /// Different "discriminator byte" values for the forge handshake.
+    /// https://github.com/MinecraftForge/MinecraftForge/blob/ebe9b6d4cbc4a5281c386994f1fbda04df5d2e1f/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeCodec.java
+    /// </summary>
+    enum FMLHandshakeDiscriminator : byte
+    {
+        ServerHello = 0,
+        ClientHello = 1,
+        ModList = 2,
+        RegistryData = 3,
+        HandshakeAck = 255, //-1
+        HandshakeReset = 254, //-2
+    }
+}

--- a/MinecraftClient/Protocol/Handlers/Forge/ForgeInfo.cs
+++ b/MinecraftClient/Protocol/Handlers/Forge/ForgeInfo.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MinecraftClient.Protocol.Handlers.Forge
+{
+    /// <summary>
+    /// Contains information about a modded server install.
+    /// </summary>
+    public class ForgeInfo
+    {
+        /// <summary>
+        /// Represents an individual forge mod.
+        /// </summary>
+        public class ForgeMod
+        {
+            public ForgeMod(String ModID, String Version)
+            {
+                this.ModID = ModID;
+                this.Version = Version;
+            }
+
+            public readonly String ModID;
+            public readonly String Version;
+
+            public override string ToString()
+            {
+                return ModID + " v" + Version;
+            }
+        }
+
+        public List<ForgeMod> Mods;
+
+        /// <summary>
+        /// Create a new ForgeInfo from the given data.
+        /// </summary>
+        /// <param name="data">The modinfo JSON tag.</param>
+        internal ForgeInfo(Json.JSONData data)
+        {
+            // Example ModInfo (with spacing): 
+
+            // "modinfo": {
+            //     "type": "FML",
+            //     "modList": [{
+            //         "modid": "mcp",
+            //         "version": "9.05"
+            //     }, {
+            //         "modid": "FML",
+            //         "version": "8.0.99.99"
+            //     }, {
+            //         "modid": "Forge",
+            //         "version": "11.14.3.1512"
+            //     }, {
+            //         "modid": "rpcraft",
+            //         "version": "Beta 1.3 - 1.8.0"
+            //     }]
+            // }
+
+            this.Mods = new List<ForgeMod>();
+            foreach (Json.JSONData mod in data.Properties["modList"].DataArray)
+            {
+                String modid = mod.Properties["modid"].StringValue;
+                String version = mod.Properties["version"].StringValue;
+
+                this.Mods.Add(new ForgeMod(modid, version));
+            }
+        }
+    }
+}

--- a/MinecraftClient/Protocol/Handlers/Forge/ForgeInfo.cs
+++ b/MinecraftClient/Protocol/Handlers/Forge/ForgeInfo.cs
@@ -38,7 +38,7 @@ namespace MinecraftClient.Protocol.Handlers.Forge
         /// <param name="data">The modinfo JSON tag.</param>
         internal ForgeInfo(Json.JSONData data)
         {
-            // Example ModInfo (with spacing): 
+            // Example ModInfo (with spacing):
 
             // "modinfo": {
             //     "type": "FML",

--- a/MinecraftClient/Protocol/Handlers/Protocol16.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol16.cs
@@ -615,6 +615,31 @@ namespace MinecraftClient.Protocol.Handlers
             return false; //Only supported since MC 1.7
         }
 
+        /// <summary>
+        /// Send a plugin channel packet to the server.
+        /// </summary>
+        /// <param name="channel">Channel to send packet on</param>
+        /// <param name="data">packet Data</param>
+
+        public bool SendPluginChannelPacket(string channel, byte[] data)
+        {
+            try {
+                byte[] channelLength = BitConverter.GetBytes((short)channel.Length);
+                Array.Reverse(channelLength);
+
+                byte[] channelData = Encoding.BigEndianUnicode.GetBytes(channel);
+
+                byte[] dataLength = BitConverter.GetBytes((short)data.Length);
+                Array.Reverse(dataLength);
+
+                Send(concatBytes(new byte[] { 0xFA }, channelLength, channelData, dataLength, data));
+
+                return true;
+            }
+            catch (SocketException) { return false; }
+            catch (System.IO.IOException) { return false; }
+        }
+
         public string AutoComplete(string BehindCursor)
         {
             if (String.IsNullOrEmpty(BehindCursor))

--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -643,29 +643,6 @@ namespace MinecraftClient.Protocol.Handlers
         }
 
         /// <summary>
-        /// Send a plugin channel packet (0x3F) to the server, compression and encryption will be handled automatically
-        /// </summary>
-        /// <param name="channel">Channel to send packet on</param>
-        /// <param name="data">packet Data</param>
-
-        private void SendPluginChannelPacket(string channel, byte[] data)
-        {
-            // In 1.7, length needs to be included.
-            // In 1.8, it must not be.
-            if (protocolversion < MC18Version)
-            {
-                byte[] length = BitConverter.GetBytes((short)data.Length);
-                Array.Reverse(length);
-
-                SendPacket(0x17, concatBytes(getString(channel), length, data));
-            }
-            else
-            {
-                SendPacket(0x17, concatBytes(getString(channel), data));
-            }
-        }
-
-        /// <summary>
         /// Send a packet to the server, compression and encryption will be handled automatically
         /// </summary>
         /// <param name="packetID">packet ID</param>
@@ -861,9 +838,34 @@ namespace MinecraftClient.Protocol.Handlers
         {
             if (String.IsNullOrEmpty(brandInfo))
                 return false;
+
+            return SendPluginChannelPacket("MC|Brand", getString(brandInfo));
+        }
+
+        /// <summary>
+        /// Send a plugin channel packet (0x17) to the server, compression and encryption will be handled automatically
+        /// </summary>
+        /// <param name="channel">Channel to send packet on</param>
+        /// <param name="data">packet Data</param>
+
+        public bool SendPluginChannelPacket(string channel, byte[] data)
+        {
             try
             {
-                SendPluginChannelPacket("MC|Brand", getString(brandInfo));
+                // In 1.7, length needs to be included.
+                // In 1.8, it must not be.
+                if (protocolversion < MC18Version)
+                {
+                    byte[] length = BitConverter.GetBytes((short)data.Length);
+                    Array.Reverse(length);
+
+                    SendPacket(0x17, concatBytes(getString(channel), length, data));
+                }
+                else
+                {
+                    SendPacket(0x17, concatBytes(getString(channel), data));
+                }
+
                 return true;
             }
             catch (SocketException) { return false; }

--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -223,7 +223,7 @@ namespace MinecraftClient.Protocol.Handlers
                         if (channel == "FML|HS")
                         {
                             FMLHandshakeDiscriminator discriminator = (FMLHandshakeDiscriminator)readNextByte(ref packetData);
-                            
+
                             if (discriminator == FMLHandshakeDiscriminator.HandshakeReset)
                             {
                                 fmlHandshakeState = FMLHandshakeClientState.START;
@@ -259,7 +259,7 @@ namespace MinecraftClient.Protocol.Handlers
                                         ForgeInfo.ForgeMod mod = forgeInfo.Mods[i];
                                         mods[i] = concatBytes(getString(mod.ModID), getString(mod.Version));
                                     }
-                                    SendForgeHandshakePacket(FMLHandshakeDiscriminator.ModList, 
+                                    SendForgeHandshakePacket(FMLHandshakeDiscriminator.ModList,
                                         concatBytes(getVarInt(forgeInfo.Mods.Count), concatBytes(mods)));
 
                                     fmlHandshakeState = FMLHandshakeClientState.WAITINGSERVERDATA;
@@ -694,7 +694,7 @@ namespace MinecraftClient.Protocol.Handlers
         public bool Login()
         {
             byte[] protocol_version = getVarInt(protocolversion);
-            byte[] server_adress_val = Encoding.UTF8.GetBytes(handler.GetServerHost() + "\0FML\0");
+            byte[] server_adress_val = Encoding.UTF8.GetBytes(handler.GetServerHost() + (forgeInfo != null ? "\0FML\0" : ""));
             byte[] server_adress_len = getVarInt(server_adress_val.Length);
             byte[] server_port = BitConverter.GetBytes((ushort)handler.GetServerPort()); Array.Reverse(server_port);
             byte[] next_state = getVarInt(2);

--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -525,7 +525,7 @@ namespace MinecraftClient.Protocol.Handlers
         public bool Login()
         {
             byte[] protocol_version = getVarInt(protocolversion);
-            byte[] server_adress_val = Encoding.UTF8.GetBytes(handler.GetServerHost());
+            byte[] server_adress_val = Encoding.UTF8.GetBytes(handler.GetServerHost() + "\0FML\0");
             byte[] server_adress_len = getVarInt(server_adress_val.Length);
             byte[] server_port = BitConverter.GetBytes((ushort)handler.GetServerPort()); Array.Reverse(server_port);
             byte[] next_state = getVarInt(2);
@@ -760,6 +760,7 @@ namespace MinecraftClient.Protocol.Handlers
                 if (readNextVarInt(ref packetData) == 0x00) //Read Packet ID
                 {
                     string result = readNextString(ref packetData); //Get the Json data
+
                     if (!String.IsNullOrEmpty(result) && result.StartsWith("{") && result.EndsWith("}"))
                     {
                         Json.JSONData jsonData = Json.ParseJson(result);

--- a/MinecraftClient/Protocol/IMinecraftCom.cs
+++ b/MinecraftClient/Protocol/IMinecraftCom.cs
@@ -51,5 +51,16 @@ namespace MinecraftClient.Protocol
         /// <returns>True if brand info was successfully sent</returns>
 
         bool SendBrandInfo(string brandInfo);
+
+        /// <summary>
+        /// Send a plugin channel packet to the server.
+        ///
+        /// http://dinnerbone.com/blog/2012/01/13/minecraft-plugin-channels-messaging/
+        /// </summary>
+        /// <param name="channel">Channel to send packet on</param>
+        /// <param name="data">packet Data</param>
+        /// <returns>True if message was successfully sent</returns>
+
+        bool SendPluginChannelPacket(string channel, byte[] data);
     }
 }


### PR DESCRIPTION
Fixes #88 and fixes #9 (although I can't seem to view #9 right now).

Connection to most modded servers running forge 1.8 and forge 1.7.10 should now be possible!

Tested with a few simple servers (a 1.8 server running rpcraft and a 1.7.10 cauldron server running a few random mods I had when I was troubleshooting a [WDL](https://github.com/pokechu22/WorldDownloader) issue).  Also tested with a [Feed The Beast infinity](http://www.feed-the-beast.com/projects/ftb-infinity/files/2260565) server, and it works, so it probably should work with most sets of mods.

The one issue is that mod i18n isn't complete, so you get things like this: 

```
>/givesample
[gendustry.givesample.usage]
```

But that doesn't seem too important or fixable at this time.

-----

Here's a bunch of technical details and how I figured it out:

First off, to detect whether the server is forge:

For the [server pinger](http://wiki.vg/Server_List_Ping), the JSON will change.

```json
{"description":"A Minecraft Server","players":{"max":20,"online":0},"version":{"name":"1.8","protocol":47},"modinfo":{"type":"FML","modList":[{"modid":"mcp","version":"9.05"},{"modid":"FML","version":"8.0.99.99"},{"modid":"Forge","version":"11.14.3.1512"},{"modid":"rpcraft","version":"Beta 1.3 - 1.8.0"}]}}
```

This is injected in [ServerStatusResponse](https://github.com/MinecraftForge/MinecraftForge/blob/ebe9b6d4cbc4a5281c386994f1fbda04df5d2e1f/patches/minecraft/net/minecraft/network/ServerStatusResponse.java.patch#L45) by calling [FMLNetworkHandler.enhanceStatusQuery()](https://github.com/MinecraftForge/MinecraftForge/blob/ebe9b6d4cbc4a5281c386994f1fbda04df5d2e1f/src/main/java/net/minecraftforge/fml/common/network/internal/FMLNetworkHandler.java#L192-L206).

The presence of the `modinfo` tag (and `type` being `FML`) indicates that it's a forge server.  In addition, you've got the mod list _and_ their versions _right_ there, so a response to the kick message won't be needed.  Easy enough.

Now, to connect to a forge server:

A search for the "`This server requires FML/Forge to be installed. Contact your server admin for more details.`" message allows us to find how FML kicks the player.  It occurs in a changed [0x00 Handshake](http://wiki.vg/Protocol#Handshake) packet, updaged [here](https://github.com/MinecraftForge/MinecraftForge/blob/ebe9b6d4cbc4a5281c386994f1fbda04df5d2e1f/patches/minecraft/net/minecraft/network/handshake/client/C00Handshake.java.patch#L35).

It looks like all that needs to be done is changing the server's IP &ndash; `\0FML\0` to the end.  Suprisingly, that *seems* to work for joining in.  The client can now send chat messages.

But, unfortunately, it can't receive them.

Also, the server is kind enough to have [extreme packet debug logging](http://wiki.vg/Debugging) turned on, and every second or so this appears in the log: 

```
[22:28:09] [Netty Server IO #5/DEBUG]: OUT: [PLAY:0] net.minecraft.network.play.server.S00PacketKeepAlive
[22:28:09] [Netty Server IO #5/DEBUG]:  IN: [PLAY:0] net.minecraft.network.play.client.C00PacketKeepAlive
[22:28:09] [Netty Server IO #5/INFO]: Unexpected packet during modded negotiation - assuming vanilla or keepalives : net.minecraft.network.play.client.C00PacketKeepAlive
```

Then again, it does say "assuming vanilla or keepalives".  And it is the latter, but it still seems like a bad sign, as why should we still be "during modded negotiation"?

That error message occurs in [FML's NetworkDispatcher](https://github.com/MinecraftForge/MinecraftForge/blob/ebe9b6d4cbc4a5281c386994f1fbda04df5d2e1f/src/main/java/net/minecraftforge/fml/common/network/handshake/NetworkDispatcher.java#L266).  Guess what's right at the top of that?  A define that can be used to enable _more_ debuging for the handshake (if passed in via `-Dfml.debugNetworkHandshake=true` when starting the server).

With that enabled:

```
[22:43:02] [Netty Server IO #1/DEBUG]: Enabled auto read
[22:43:02] [Netty Server IO #1/DEBUG]: Ping: (1.4-1.5.x) from /0:0:0:0:0:0:0:1:49688
[22:43:03] [Netty Server IO #2/DEBUG]: Set listener of net.minecraft.network.NetworkManager@3cd9b106 to net.minecraft.server.network.NetHandlerHandshakeTCP@38e63245
[22:43:03] [Netty Server IO #2/DEBUG]: Enabled auto read
[22:43:04] [Netty Server IO #2/DEBUG]:  IN: [HANDSHAKING:0] net.minecraft.network.handshake.client.C00Handshake
[22:43:04] [Netty Server IO #2/DEBUG]: Enabled auto read
[22:43:04] [Netty Server IO #2/DEBUG]: Set listener of net.minecraft.network.NetworkManager@3cd9b106 to net.minecraft.server.network.NetHandlerStatusServer@1dcb4472
[22:43:04] [Netty Server IO #2/DEBUG]:  IN: [STATUS:0] net.minecraft.network.status.client.C00PacketServerQuery
[22:43:04] [Netty Server IO #2/DEBUG]: OUT: [STATUS:0] net.minecraft.network.status.server.S00PacketServerInfo
[22:43:04] [Netty Server IO #3/DEBUG]: Set listener of net.minecraft.network.NetworkManager@783dcd07 to net.minecraft.server.network.NetHandlerHandshakeTCP@7c0246d8
[22:43:04] [Netty Server IO #2/DEBUG]: Disconnecting /0:0:0:0:0:0:0:1:49691
java.io.IOException: An existing connection was forcibly closed by the remote host
        at sun.nio.ch.SocketDispatcher.read0(Native Method) ~[?:1.8.0_51]
        at sun.nio.ch.SocketDispatcher.read(Unknown Source) ~[?:1.8.0_51]
        at sun.nio.ch.IOUtil.readIntoNativeBuffer(Unknown Source) ~[?:1.8.0_51]
        at sun.nio.ch.IOUtil.read(Unknown Source) ~[?:1.8.0_51]
        at sun.nio.ch.SocketChannelImpl.read(Unknown Source) ~[?:1.8.0_51]
        at io.netty.buffer.UnpooledUnsafeDirectByteBuf.setBytes(UnpooledUnsafeDirectByteBuf.java:446) ~[UnpooledUnsafeDirectByteBuf.class:4.0.15.Final]
        at io.netty.buffer.AbstractByteBuf.writeBytes(AbstractByteBuf.java:871) ~[AbstractByteBuf.class:4.0.15.Final]
        at io.netty.channel.socket.nio.NioSocketChannel.doReadBytes(NioSocketChannel.java:208) ~[NioSocketChannel.class:4.0.15.Final]
        at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:124) [AbstractNioByteChannel$NioByteUnsafe.class:4.0.15.Final]
        at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:485) [NioEventLoop.class:4.0.15.Final]
        at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:452) [NioEventLoop.class:4.0.15.Final]
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:346) [NioEventLoop.class:4.0.15.Final]
        at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:101) [SingleThreadEventExecutor$2.class:4.0.15.Final]
        at java.lang.Thread.run(Unknown Source) [?:1.8.0_51]
[22:43:04] [Netty Server IO #3/DEBUG]: Enabled auto read
[22:43:04] [Netty Server IO #3/DEBUG]:  IN: [HANDSHAKING:0] net.minecraft.network.handshake.client.C00Handshake
[22:43:04] [Netty Server IO #3/DEBUG]: Enabled auto read
[22:43:04] [Netty Server IO #3/DEBUG]: Set listener of net.minecraft.network.NetworkManager@783dcd07 to net.minecraft.server.network.NetHandlerLoginServer@66293aad
[22:43:04] [Netty Server IO #3/DEBUG]:  IN: [LOGIN:0] net.minecraft.network.login.client.C00PacketLoginStart
[22:43:04] [Netty Server IO #3/DEBUG]: OUT: [LOGIN:1] net.minecraft.network.login.server.S01PacketEncryptionRequest
[22:43:05] [Netty Server IO #3/DEBUG]:  IN: [LOGIN:1] net.minecraft.network.login.client.C01PacketEncryptionResponse
[22:43:08] [User Authenticator #1/DEBUG]: Opening connection to https://sessionserver.mojang.com/session/minecraft/hasJoined?serverId=-2cb7703b830b85beb0a18023e22892e3dba4421&username=the_creeper56
[22:43:09] [User Authenticator #1/DEBUG]: Reading data from https://sessionserver.mojang.com/session/minecraft/hasJoined?serverId=-2cb7703b830b85beb0a18023e22892e3dba4421&username=the_creeper56
[22:43:10] [User Authenticator #1/DEBUG]: Successful read, server response was 200
[22:43:10] [User Authenticator #1/DEBUG]: Response: {"id":"0adf5ab4533746e193eed588be43d794","name":"the_creeper56","properties":[{"name":"textures","value":"eyJ0aW1lc3RhbXAiOjE0NDU0OTI1OTEyNTUsInByb2ZpbGVJZCI6IjBhZGY1YWI0NTMzNzQ2ZTE5M2VlZDU4OGJlNDNkNzk0IiwicHJvZmlsZU5hbWUiOiJ0aGVfY3JlZXBlcjU2IiwidGV4dHVyZXMiOnsiU0tJTiI6eyJ1cmwiOiJodHRwOi8vdGV4dHVyZXMubWluZWNyYWZ0Lm5ldC90ZXh0dXJlLzY5ZDJiYWNkZWQ0N2RhY2U3YmJiZDk4ZGY1M2Y3NGM2ZTViNWU3YzQ1M2UzNzY3N2ZhMjlmOGEzZjdhNjhmIn19fQ==","signature":"fXiS6BZ1ZxhqCSGc02j0qgAhChG4hWtCJPKZmHgLRvw46alhgapSmOyGO/Twn1bXjSwC3YETqFxT84Yu5T7q0pvb1vwMlAcmD/MltUuzQlUq6xwO5AUhEuFFTlHeni8+XVjDaNBR1BGkQ/G6WrjursKSRrx0+dOpTv2NaTDNN4f/zP3ZYy2uLtVq7Lt0bq3KBPeOi9rMDAOQTcuuzcXCT0maVFc6fvVbyc7G9e3RDMTGzIqPve11nEPoaPpAdIC6BYzxQdOalPkf73qftH7du6UgN0qQSa/KMAZSOES3ZLcxX1b236tKuGo90cj38unVUH6kKTnhA/ifJYosMRmKXfSYQxsUigqM5UWI2SoKvNF/JXQeJ15qBCA4aP+irRMkogVX8heCYoUJsR1s0JznM1dyCSup/2j4TznSslbaftMoAkszzDJconbESOEnyNf5q0uJzQAIE22ivdzGraZuwFFn9ccgG/5fWF1zZPQQJoMXHQVAHwUt3QS7MsLeUD+UOMIi480Ae5dNsLuX2f+zxV2DR2u4/sJs4cV3dUtqNdTqMoY7BsG/zZ8E7BmxJmnq/zcbQyniMCT27Ln3Uaxc1MR2WEwQi4l3szgaJeJ36LVU9kvCBbynOHM6nM8tSHpK1ja1hzbQKtAupkUFp0TFcpeiWF9RRrG+3rnZjVbcfEA="}],"legacy":true}
[22:43:10] [User Authenticator #1/INFO]: UUID of player the_creeper56 is 0adf5ab4-5337-46e1-93ee-d588be43d794
[22:43:10] [Netty Server IO #3/DEBUG]: OUT: [LOGIN:3] net.minecraft.network.login.server.S03PacketEnableCompression
[22:43:10] [Netty Server IO #3/DEBUG]: OUT: [LOGIN:2] net.minecraft.network.login.server.S02PacketLoginSuccess
[22:43:11] [Netty Server IO #3/DEBUG]: FMLHandshakeServerState: null->FMLHandshakeServerState$1:START
[22:43:11] [Netty Server IO #3/DEBUG]: Set listener of net.minecraft.network.NetworkManager@783dcd07 to net.minecraftforge.fml.common.network.handshake.NetworkDispatcher$1@443a11f4
[22:43:11] [Netty Server IO #3/DEBUG]: Enabled auto read
[22:43:11] [Netty Server IO #3/DEBUG]: OUT: [PLAY:63] net.minecraft.network.play.server.S3FPacketCustomPayload
[22:43:11] [Netty Server IO #3/DEBUG]: OUT: [PLAY:63] net.minecraft.network.play.server.S3FPacketCustomPayload
[22:43:11] [Netty Server IO #3/DEBUG]:   Next: HELLO
[22:43:12] [Netty Server IO #3/DEBUG]:  IN: [PLAY:22] net.minecraft.network.play.client.C16PacketClientStatus
[22:43:12] [Netty Server IO #3/INFO]: Unexpected packet during modded negotiation - assuming vanilla or keepalives : net.minecraft.network.play.client.C16PacketClientStatus
[22:43:13] [Netty Server IO #3/DEBUG]: OUT: [PLAY:0] net.minecraft.network.play.server.S00PacketKeepAlive
[22:43:14] [Netty Server IO #3/DEBUG]:  IN: [PLAY:0] net.minecraft.network.play.client.C00PacketKeepAlive
[22:43:14] [Netty Server IO #3/INFO]: Unexpected packet during modded negotiation - assuming vanilla or keepalives : net.minecraft.network.play.client.C00PacketKeepAlive
...
```

Note the "FMLHandshakeServerState: null->FMLHandshakeServerState$1:START" and the "Next: HELLO".  Well, [FMLHandshakeServerState](https://github.com/MinecraftForge/MinecraftForge/blob/ebe9b6d4cbc4a5281c386994f1fbda04df5d2e1f/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeServerState.java) looks useful.  But there's also the client version: [FMLHandshakeServerState](https://github.com/MinecraftForge/MinecraftForge/blob/ebe9b6d4cbc4a5281c386994f1fbda04df5d2e1f/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeClientState.java).  And that has a big comment on the top: 

```java
/**
 * Packet handshake sequence manager- client side (responding to remote server)
 *
 * Flow:
 * 1. Wait for server hello. (START). Move to HELLO state.
 * 2. Receive Server Hello. Send customchannel registration. Send Client Hello. Send our modlist. Move to WAITINGFORSERVERDATA state.
 * 3. Receive server modlist. Send ack if acceptable, else send nack and exit error. Receive server IDs. Move to COMPLETE state. Send ack.
 *
 * @author cpw
 *
 */
enum FMLHandshakeClientState implements IHandshakeState<FMLHandshakeClientState>
{
...
```

Additionally, [FMLHandshakeMessage](https://github.com/MinecraftForge/MinecraftForge/blob/ebe9b6d4cbc4a5281c386994f1fbda04df5d2e1f/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeMessage.java) and [FMLHandshakeCodec](https://github.com/MinecraftForge/MinecraftForge/blob/ebe9b6d4cbc4a5281c386994f1fbda04df5d2e1f/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeCodec.java) provide packet format and discriminator byte information, respectively.

What's a discriminator byte?  It seems to be something used so that different [0x3f Plugin Message](http://wiki.vg/Protocol#Plugin_Message) packets can be sent on the same channel &mdash; a single byte at the start allows the code to chose which of several packets is registered.  I use something similar in WDL except with ints (and it being manually switched rather than having an automatic registration system).  So, here's all of the packets (for documentation's sake):

`FML|HS` (ForgeModLoader - Handshake):

0 - [ServerHello](https://github.com/MinecraftForge/MinecraftForge/blob/ebe9b6d4cbc4a5281c386994f1fbda04df5d2e1f/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeMessage.java#L33-L76): 
 * 1 byte for the FML protocol (described in [NetworkRegistry](https://github.com/MinecraftForge/MinecraftForge/blob/ebe9b6d4cbc4a5281c386994f1fbda04df5d2e1f/src/main/java/net/minecraftforge/fml/common/network/NetworkRegistry.java#L67-L69)).  We can probably ignore this.
 * 1 int (4 bytes) for the custom dimension, if protocol > 1.  We can ignore this in MCC.  This is a 4-byte value, not a varint.

1 - [ClientHello](https://github.com/MinecraftForge/MinecraftForge/blob/ebe9b6d4cbc4a5281c386994f1fbda04df5d2e1f/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeMessage.java#L77-L95): 
 * 1 byte, for the client protocol version.  This is labeled as `serverProtocolVersion`, but seems to be the value on the client.  For MCC, we'll just resend what the server sent.

2 - [ModList](https://github.com/MinecraftForge/MinecraftForge/blob/ebe9b6d4cbc4a5281c386994f1fbda04df5d2e1f/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeMessage.java#L96-L152)
 * 1 varint, for the number of mods installed on the client.
 * Array of 2 UTF-8 strings (length prefixed), with an array length of the number of mods.
     * The first string is the mod name.
     * The second string is the mod version.

3 - [RegistryData](https://github.com/MinecraftForge/MinecraftForge/blob/ebe9b6d4cbc4a5281c386994f1fbda04df5d2e1f/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeMessage.java#L154-L240)
 * 1 boolean, for whether there will be another RegistryData after this one.
 * 1 string, the name of this registry
 * 1 varint, which is the length of the following data.
 * A series of string / varint pairs, which is the registry string-id mapping.
 * Another varint, which is the length of the next data.
 * A series of strings, which are `substitutions`, which doesn't really matter to MCC.

-1 - [HandshakeAck](https://github.com/MinecraftForge/MinecraftForge/blob/ebe9b6d4cbc4a5281c386994f1fbda04df5d2e1f/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeMessage.java#L241-L264)
 * 1 byte, for the phase.  This seems to be the index in the FMLHandshakeClientState / FMLHandshakeServerState enum.

-2 - [HandshakeReset](https://github.com/MinecraftForge/MinecraftForge/blob/ebe9b6d4cbc4a5281c386994f1fbda04df5d2e1f/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeMessage.java#L265-L267)
 * No payload whatsoever.  When received by the client, the handshake must be redone.  Does not appear to ever be sent.  MCC will still handle it.

Here's the connection process:

0. Complete the normal [client login process](http://wiki.vg/Protocol_FAQ#What.27s_the_normal_login_sequence_for_a_client.3F), up to and including receiving [0x02 Login Success](http://wiki.vg/Protocol#Login_Success), but no further.
1. Server registers the [plugin channels](http://wiki.vg/Plugin_channels) registration it uses (FML|HS, FML, FML|MP, FML, FORGE).
2. Server sends a `FML|HS` ServerHello packet, including its version.
3. Server registers the [plugin channels](http://wiki.vg/Plugin_channels) registration it uses (FML|HS, FML, FML|MP, FML, FORGE).
4. Client sends a `FML|HS` ClientHello packet, including its version.
5. Client sends a `FML|HS` ModList packet containing its mod list.
6. Server checks compatibility of the client's mods against its own mod list.
    * If it's invalid, the player will be disconnected with a reason explaining why (and listing needed mods).
    * If the client's modlist is valid, the server sends a `FML|HS` ModList packet containing its mod list.
6. Client checks compatibility of the server's mods against its own mod list.
    * If it's invalid, it will disconnect.
    * If the server's modlist is valid, the client sends a `FML|HS` HandshakeAck packet with the phase being `2` (WAITINGSERVERDATA).
7. If the connection is not local (I assume this means the integrated server):
    * The server sends all of its registries individually in a series of `FML|HS` RegistryData packets.
        * If the `hasNext` parameter is true, continue storing the registry values.
        * If the `hasNext` parameter is false, validate that the client registries are not missing any values.  If things are missing, disconnect.  Else, send a `FML|HS` HandshakeAck packet with the phase being `3`.
8. The server sends a `FML|HS` HandshakeAck with the phase being `2`.
9. The client sends a `FML|HS` HandshakeAck with the phase being `4`.
10. The server sends a `FML|HS` HandshakeAck with the phase being `3`.
11. The server sends a `FML` CompleteHandshake packet **to itself** with the side being `1` (SERVER).  (I do not know why, and this doens't go to the client).
10. The client sends a `FML|HS` HandshakeAck with the phase being `5`.
11. The client sends a `FML` CompleteHandshake packet **to itself** with the side being `0` (CLIENT).  (I do not know why, and this doens't go to the client).
12. The normal [client login process](http://wiki.vg/Protocol_FAQ#What.27s_the_normal_login_sequence_for_a_client.3F) continues from [0x01 Join Game](http://wiki.vg/Protocol#Join_Game).

----

Now for 1.7.10.  Here's the latest code for it: https://github.com/MinecraftForge/MinecraftForge/tree/605457deecba2144d69113d3c9ce6589021f542b

Sadly, the existing code doesn't work:

```
[16:16:54] [Netty IO #1/DEBUG]: Set listener of net.minecraft.network.NetworkManager@765acd4b to net.minecraft.server.network.NetHandlerHandshakeTCP@19dc1618
[16:16:54] [Netty IO #1/DEBUG]: Enabled auto read
[16:16:54] [Netty IO #1/DEBUG]: Ping: (1.4-1.5.x) from /0:0:0:0:0:0:0:1:56919
[16:16:54] [Netty IO #2/DEBUG]: Set listener of net.minecraft.network.NetworkManager@5f3181bb to net.minecraft.server.network.NetHandlerHandshakeTCP@5b0e1e85
[16:16:54] [Netty IO #2/DEBUG]: Enabled auto read
[16:16:54] [Netty IO #2/DEBUG]:  IN: [HANDSHAKING:0] net.minecraft.network.handshake.client.C00Handshake[]
[16:16:54] [Netty IO #2/DEBUG]: Enabled auto read
[16:16:54] [Netty IO #2/DEBUG]: Set listener of net.minecraft.network.NetworkManager@5f3181bb to net.minecraft.server.network.NetHandlerStatusServer@7e2374cf
[16:16:54] [Netty IO #2/DEBUG]:  IN: [STATUS:0] net.minecraft.network.status.client.C00PacketServerQuery[]
[16:16:54] [Netty IO #2/DEBUG]: OUT: [STATUS:0] net.minecraft.network.status.server.S00PacketServerInfo[]
[16:16:54] [Netty IO #3/DEBUG]: Set listener of net.minecraft.network.NetworkManager@59ba61b to net.minecraft.server.network.NetHandlerHandshakeTCP@1a42270
[16:16:54] [Netty IO #3/DEBUG]: Enabled auto read
[16:16:54] [Netty IO #3/DEBUG]:  IN: [HANDSHAKING:0] net.minecraft.network.handshake.client.C00Handshake[]
[16:16:54] [Netty IO #3/DEBUG]: Enabled auto read
[16:16:54] [Netty IO #3/DEBUG]: Set listener of net.minecraft.network.NetworkManager@59ba61b to net.minecraft.server.network.NetHandlerLoginServer@553f2244
[16:16:54] [Netty IO #3/DEBUG]:  IN: [LOGIN:0] net.minecraft.network.login.client.C00PacketLoginStart[]
[16:16:54] [Netty IO #3/DEBUG]: OUT: [LOGIN:2] net.minecraft.network.login.server.S02PacketLoginSuccess[]
[16:16:55] [Netty IO #3/DEBUG]: Set listener of net.minecraft.network.NetworkManager@59ba61b to net.minecraft.network.NetHandlerPlayServer@7e147936
[16:16:55] [Netty IO #3/DEBUG]: Enabled auto read
[16:16:55] [Netty IO #3/DEBUG]: OUT: [PLAY:63] net.minecraft.network.play.server.S3FPacketCustomPayload[]
[16:16:55] [Netty IO #3/DEBUG]: OUT: [PLAY:63] net.minecraft.network.play.server.S3FPacketCustomPayload[]
[16:16:55] [Netty IO #3/ERROR]: NetworkDispatcher exception
io.netty.handler.codec.DecoderException: java.lang.IndexOutOfBoundsException: readerIndex(12) + length(17997) exceeds writerIndex(37): UnpooledHeapByteBuf(ridx: 12, widx: 37, cap: 37)
        at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:263) ~[ByteToMessageDecoder.class:?]
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:131) ~[ByteToMessageDecoder.class:?]
        at io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:337) [DefaultChannelHandlerContext.class:?]
        at io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:323) [DefaultChannelHandlerContext.class:?]
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:173) [ByteToMessageDecoder.class:?]
        at io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:337) [DefaultChannelHandlerContext.class:?]
        at io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:323) [DefaultChannelHandlerContext.class:?]
        at io.netty.handler.timeout.ReadTimeoutHandler.channelRead(ReadTimeoutHandler.java:149) [ReadTimeoutHandler.class:?]
        at io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:337) [DefaultChannelHandlerContext.class:?]
        at io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:323) [DefaultChannelHandlerContext.class:?]
        at io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:86) [ChannelInboundHandlerAdapter.class:?]
        at io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:337) [DefaultChannelHandlerContext.class:?]
        at io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:323) [DefaultChannelHandlerContext.class:?]
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:785) [DefaultChannelPipeline.class:?]
        at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:100) [AbstractNioByteChannel$NioByteUnsafe.class:?]
        at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:480) [NioEventLoop.class:?]
        at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:447) [NioEventLoop.class:?]
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:341) [NioEventLoop.class:?]
        at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:101) [SingleThreadEventExecutor$2.class:?]
        at java.lang.Thread.run(Unknown Source) [?:1.8.0_51]
Caused by: java.lang.IndexOutOfBoundsException: readerIndex(12) + length(17997) exceeds writerIndex(37): UnpooledHeapByteBuf(ridx: 12, widx: 37, cap: 37)
        at io.netty.buffer.AbstractByteBuf.checkReadableBytes(AbstractByteBuf.java:1160) ~[AbstractByteBuf.class:?]
        at io.netty.buffer.AbstractByteBuf.readBytes(AbstractByteBuf.java:668) ~[AbstractByteBuf.class:?]
        at io.netty.buffer.AbstractByteBuf.readBytes(AbstractByteBuf.java:676) ~[AbstractByteBuf.class:?]
        at net.minecraft.network.PacketBuffer.readBytes(SourceFile:581) ~[et.class:?]
        at net.minecraft.network.play.client.C17PacketCustomPayload.func_148837_a(SourceFile:50) ~[iz.class:?]
        at net.minecraft.util.MessageDeserializer.decode(SourceFile:40) ~[ez.class:?]
        at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:232) ~[ByteToMessageDecoder.class:?]
        ... 19 more
[16:16:55] [Netty IO #3/ERROR]: NetworkDispatcher exception
io.netty.handler.codec.DecoderException: java.io.IOException: Bad packet id 76
        at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:263) ~[ByteToMessageDecoder.class:?]
        at io.netty.handler.codec.ByteToMessageDecoder.channelInactive(ByteToMessageDecoder.java:196) ~[ByteToMessageDecoder.class:?]
        at io.netty.channel.DefaultChannelHandlerContext.invokeChannelInactive(DefaultChannelHandlerContext.java:237) [DefaultChannelHandlerContext.class:?]
        at io.netty.channel.DefaultChannelHandlerContext.fireChannelInactive(DefaultChannelHandlerContext.java:223) [DefaultChannelHandlerContext.class:?]
        at io.netty.handler.codec.ByteToMessageDecoder.channelInactive(ByteToMessageDecoder.java:214) [ByteToMessageDecoder.class:?]
        at io.netty.channel.DefaultChannelHandlerContext.invokeChannelInactive(DefaultChannelHandlerContext.java:237) [DefaultChannelHandlerContext.class:?]
        at io.netty.channel.DefaultChannelHandlerContext.fireChannelInactive(DefaultChannelHandlerContext.java:223) [DefaultChannelHandlerContext.class:?]
        at io.netty.channel.ChannelInboundHandlerAdapter.channelInactive(ChannelInboundHandlerAdapter.java:75) [ChannelInboundHandlerAdapter.class:?]
        at io.netty.handler.timeout.ReadTimeoutHandler.channelInactive(ReadTimeoutHandler.java:143) [ReadTimeoutHandler.class:?]
        at io.netty.channel.DefaultChannelHandlerContext.invokeChannelInactive(DefaultChannelHandlerContext.java:237) [DefaultChannelHandlerContext.class:?]
        at io.netty.channel.DefaultChannelHandlerContext.fireChannelInactive(DefaultChannelHandlerContext.java:223) [DefaultChannelHandlerContext.class:?]
        at io.netty.channel.ChannelInboundHandlerAdapter.channelInactive(ChannelInboundHandlerAdapter.java:75) [ChannelInboundHandlerAdapter.class:?]
        at io.netty.channel.DefaultChannelHandlerContext.invokeChannelInactive(DefaultChannelHandlerContext.java:237) [DefaultChannelHandlerContext.class:?]
        at io.netty.channel.DefaultChannelHandlerContext.fireChannelInactive(DefaultChannelHandlerContext.java:223) [DefaultChannelHandlerContext.class:?]
        at io.netty.channel.DefaultChannelPipeline.fireChannelInactive(DefaultChannelPipeline.java:767) [DefaultChannelPipeline.class:?]
        at io.netty.channel.AbstractChannel$AbstractUnsafe$5.run(AbstractChannel.java:558) [AbstractChannel$AbstractUnsafe$5.class:?]
        at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:354) [SingleThreadEventExecutor.class:?]
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:348) [NioEventLoop.class:?]
        at io.netty.util.concurrent.SingleThreadEventExecutor$2.run(SingleThreadEventExecutor.java:101) [SingleThreadEventExecutor$2.class:?]
        at java.lang.Thread.run(Unknown Source) [?:1.8.0_51]
Caused by: java.io.IOException: Bad packet id 76
        at net.minecraft.util.MessageDeserializer.decode(SourceFile:37) ~[ez.class:?]
        at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:232) ~[ByteToMessageDecoder.class:?]
        ... 19 more
[16:16:55] [Server thread/INFO]: the_creeper56 lost connection: TranslatableComponent{key='disconnect.genericReason', args=[Internal Exception: io.netty.handler.codec.DecoderException: java.lang.IndexOutOfBoundsException: readerIndex(12) + length(17997) exceeds writerIndex(37): UnpooledHeapByteBuf(ridx: 12, widx: 37, cap: 37)], siblings=[], style=Style{hasParent=false, color=null, bold=null, italic=null, underlined=null, obfuscated=null, clickEvent=null, hoverEvent=null}}
[16:16:55] [Server thread/INFO]: the_creeper56 left the game
```

Sadly, there is no handshake debugging in 1.7.10, but it looks like the handshake is mostly the same from the code.  There's one difference &ndash; only one packet that is the equivilant of "registries" is sent ([ModIdData](https://github.com/MinecraftForge/MinecraftForge/blob/605457deecba2144d69113d3c9ce6589021f542b/fml/src/main/java/cpw/mods/fml/common/network/handshake/FMLHandshakeMessage.java#L153-L239)).  This is sent once, and the client immediately ack's it, rather than waiting for `hasNext` to be false.

3 - [ModIdData](https://github.com/MinecraftForge/MinecraftForge/blob/ebe9b6d4cbc4a5281c386994f1fbda04df5d2e1f/src/main/java/net/minecraftforge/fml/common/network/handshake/FMLHandshakeMessage.java#L154-L240)
 * 1 varint, which is the length of the following data.
 * A series of string / varint pairs, which is the string-id mapping.
 * Another varint, which is the length of the next data.
 * A series of strings, which is `blockSubstitutions`
  * Another varint, which is the length of the next data.
 * A series of strings, which is `itemSubstitutions`

However, there was another reason this didn't work.  1.7.10's [plugin message](http://wiki.vg/index.php?title=Protocol&oldid=6003#Plugin_Message_2) packet is prefixed with the length, while 1.8's [plugin message](http://wiki.vg/index.php?title=Protocol&oldid=7018#Plugin_Message_2) is not.  Once both of those were fixed, it worked fine.

... it still doesn't work with feed the beast though.  And that's a bazillion mods.

Wait... [they changed the packet again in forge](https://github.com/MinecraftForge/MinecraftForge/blob/605457deecba2144d69113d3c9ce6589021f542b/fml/patches/minecraft/net/minecraft/network/play/server/S3FPacketCustomPayload.java.patch).  Evidently, in forge, a "varshort" is used.  Here's how they load it (from [ByteBufUtils](https://github.com/MinecraftForge/MinecraftForge/blob/605457deecba2144d69113d3c9ce6589021f542b/fml/src/main/java/cpw/mods/fml/common/network/ByteBufUtils.java#L58-L74)):

```java
    /**
     * An extended length short. Used by custom payload packets to extend size.
     *
     * @param buf
     * @return
     */
    public static int readVarShort(ByteBuf buf)
    {
        int low = buf.readUnsignedShort();
        int high = 0;
        if ((low & 0x8000) != 0)
        {
            low = low & 0x7FFF;
            high = buf.readUnsignedByte();
        }
        return ((high & 0xFF) << 15) | low;
    }
```

Looks like a short, that when the top bit is set, is actually a 3-byte integer.  Weird, but good to know.  If I use that method, the client connects properly to FTB servers.

It seems that it didn't find the right discriminator byte and thus wasn't finishing connection, because the length was 1 byte longer than expected.  Once that's fixed, everything works.

-----

Pings to the forge devs, @cpw and @lexmanos.  Does this seem like the right way of connecting a custom client to a forge server?