### PR TITLE
Add an option to add a delay between bot messages

### DIFF
--- a/MinecraftClient/McTcpClient.cs
+++ b/MinecraftClient/McTcpClient.cs
@@ -459,6 +459,7 @@ namespace MinecraftClient
                 try
                 {
                     bots[i].Update();
+                    bots[i].ProcessQueuedText();
                 }
                 catch (Exception e)
                 {

--- a/MinecraftClient/Settings.cs
+++ b/MinecraftClient/Settings.cs
@@ -44,6 +44,7 @@ namespace MinecraftClient
         public static string TranslationsFile_Website_Download = "http://resources.download.minecraft.net";
         public static TimeSpan splitMessageDelay = TimeSpan.FromSeconds(2);
         public static List<string> Bots_Owners = new List<string>();
+        public static TimeSpan botMessageDelay = TimeSpan.FromSeconds(2);
         public static string Language = "en_GB";
         public static bool chatTimeStamps = false;
         public static bool interactiveMode = true;
@@ -182,6 +183,7 @@ namespace MinecraftClient
                                                 case "showxpbarmessages": DisplayXPBarMessages = str2bool(argValue); break;
                                                 case "terrainandmovements": TerrainAndMovements = str2bool(argValue); break;
                                                 case "privatemsgscmdname": PrivateMsgsCmdName = argValue.ToLower().Trim(); break;
+                                                case "botmessagedelay": botMessageDelay = TimeSpan.FromSeconds(str2int(argValue)); break;
 
                                                 case "botowners":
                                                     Bots_Owners.Clear();
@@ -406,6 +408,7 @@ namespace MinecraftClient
                 + "consoletitle=%username%@%serverip% - Minecraft Console Client\r\n"
                 + "internalcmdchar=slash #use 'none', 'slash' or 'backslash'\r\n"
                 + "splitmessagedelay=2 #seconds between each part of a long message\r\n"
+                + "botmessagedelay=2 #seconds to delay between message a bot makes to avoid accidental spam\n\n"
                 + "mcversion=auto #use 'auto' or '1.X.X' values\r\n"
                 + "brandinfo=mcc #use 'mcc','vanilla', or 'none'\r\n"
                 + "chatbotlogfile= #leave empty for no logfile\r\n"


### PR DESCRIPTION
Because bots can send several messages quickly, this adds an option to slow down the rate at which messages are produced (to avoid issues with antispam plugins).  This should help solve part of the troubles @mobdon was having in #105.

Right now the default time is 2 seconds per message.  However, messages are sent imediately if the bot doesn't need to delay (so if it's a bot that only outputs one or two messages, those will still happen imediately).  Also, note that it's limited per-bot right now.

I also added an optional parameter to the SendText method so that bots can avoid this behavior if they need to.  In some cases, they'll want to send multiple messages.