### PR TITLE
Update to 1.8's language files.

### DIFF
--- a/MinecraftClient/Protocol/Handlers/ChatParser.cs
+++ b/MinecraftClient/Protocol/Handlers/ChatParser.cs
@@ -85,12 +85,13 @@ namespace MinecraftClient.Protocol.Handlers
                 ConsoleIO.WriteLine("Downloading '" + Settings.Language + ".lang' from Mojang servers...");
                 try
                 {
-                        string assets_index = downloadString(Settings.TranslationsFile_Website_Index);
-                        string[] tmp = assets_index.Split(new string[] { "lang/" + Settings.Language + ".lang" }, StringSplitOptions.None);
-                        tmp = tmp[1].Split(new string[] { "hash\": \"" }, StringSplitOptions.None);
-                        string hash = tmp[1].Split('"')[0]; //Translations file identifier on Mojang's servers
-                        System.IO.File.WriteAllText(Language_File, downloadString(Settings.TranslationsFile_Website_Download + '/' + hash.Substring(0, 2) + '/' + hash));
-                        ConsoleIO.WriteLine("Done. File saved as '" + Language_File + '\'');
+                    string assets_index = downloadString(Settings.TranslationsFile_Website_Index);
+                    string[] tmp = assets_index.Split(new string[] { "minecraft/lang/" + Settings.Language + ".lang" }, StringSplitOptions.None);
+                    tmp = tmp[1].Split(new string[] { "hash\": \"" }, StringSplitOptions.None);
+                    string hash = tmp[1].Split('"')[0]; //Translations file identifier on Mojang's servers
+                    System.IO.File.WriteAllText(Language_File, downloadString(Settings.TranslationsFile_Website_Download + '/' + hash.Substring(0, 2) + '/' + hash));
+                    Console.WriteLine(hash);
+                    ConsoleIO.WriteLine("Done. File saved as '" + Language_File + '\'');
                 }
                 catch
                 {

--- a/MinecraftClient/Settings.cs
+++ b/MinecraftClient/Settings.cs
@@ -39,8 +39,8 @@ namespace MinecraftClient
         public static string ProxyPassword = "";
 
         //Other Settings
-        public static string TranslationsFile_FromMCDir = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + @"\.minecraft\assets\objects\9e\9e2fdc43fc1c7024ff5922b998fadb2971a64ee0"; //MC 1.7.4 en_GB.lang
-        public static string TranslationsFile_Website_Index = "https://s3.amazonaws.com/Minecraft.Download/indexes/1.7.4.json";
+        public static string TranslationsFile_FromMCDir = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + @"\.minecraft\assets\objects\03\03f31164d234f10a3230611656332f1756e570a9"; //MC 1.8 en_GB.lang
+        public static string TranslationsFile_Website_Index = "https://s3.amazonaws.com/Minecraft.Download/indexes/1.8.json";
         public static string TranslationsFile_Website_Download = "http://resources.download.minecraft.net";
         public static TimeSpan splitMessageDelay = TimeSpan.FromSeconds(2);
         public static List<string> Bots_Owners = new List<string>();


### PR DESCRIPTION
I ocasionally see untranslated messages; this should resolve all of them.

The changes to Settings.cs, the core changes, just update the index file used and the normal hash.  The changes in ChatParser.cs primarilly fix the name: 1.7.4 used 'lang/en-GB.lang' but 1.7.10 and 1.8 use 'minecraft/lang/en-GB.lang' and 'realms/lang/en-GB.lang' (and realms comes first), meaning that the wrong language file is selected.  The name is updated to make sure the right file is used.  I also corrected the indentation in that block.