### PR TITLE
Give bots access to plugin channels

### DIFF
--- a/MinecraftClient/ChatBot.cs
+++ b/MinecraftClient/ChatBot.cs
@@ -41,6 +41,7 @@ namespace MinecraftClient
         private McTcpClient Handler { get { return master != null ? master.Handler : _handler; } }
         private McTcpClient _handler = null;
         private ChatBot master = null;
+        private List<string> registeredPluginChannels = new List<String>();
         private Queue<string> chatQueue = new Queue<string>();
         private DateTime? lastMessageSentTime = DateTime.MinValue;
         private bool CanSendTextNow
@@ -99,6 +100,17 @@ namespace MinecraftClient
         /// <returns>Return TRUE if the client is about to restart</returns>
 
         public virtual bool OnDisconnect(DisconnectReason reason, string message) { return false; }
+
+        /// <summary>
+        /// Called when a plugin channel message is received.
+        /// The given channel must have previously been registered with RegisterPluginChannel.
+        /// This can be used to communicate with server mods or plugins.  See wiki.vg for more
+        /// information about plugin channels: http://wiki.vg/Plugin_channel
+        /// </summary>
+        /// <param name="channel">The name of the channel</param>
+        /// <param name="data">The payload for the message</param>
+
+        public virtual void OnPluginMessage(string channel, byte[] data) { }
 
         /* =================================================================== */
         /*  ToolBox - Methods below might be useful while creating your bot.   */
@@ -595,6 +607,49 @@ namespace MinecraftClient
                 LogToConsole("File not found: " + Settings.Alerts_MatchesFile);
                 return new string[0];
             }
+        }
+
+        /// <summary>
+        /// Registers the given plugin channel for use by this chatbot.
+        /// </summary>
+        /// <param name="channel">The name of the channel to register</param>
+
+        protected void RegisterPluginChannel(string channel)
+        {
+            this.registeredPluginChannels.Add(channel);
+            Handler.RegisterPluginChannel(channel, this);
+        }
+
+        /// <summary>
+        /// Unregisters the given plugin channel, meaning this chatbot can no longer use it.
+        /// </summary>
+        /// <param name="channel">The name of the channel to unregister</param>
+
+        protected void UnregisterPluginChannel(string channel)
+        {
+            this.registeredPluginChannels.RemoveAll(chan => chan == channel);
+            Handler.UnregisterPluginChannel(channel, this);
+        }
+
+        /// <summary>
+        /// Sends the given plugin channel message to the server, if the channel has been registered.
+        /// See http://wiki.vg/Plugin_channel for more information about plugin channels.
+        /// </summary>
+        /// <param name="channel">The channel to send the message on.</param>
+        /// <param name="data">The data to send.</param>
+        /// <param name="sendEvenIfNotRegistered">Should the message be sent even if it hasn't been registered by the server or this bot?  (Some Minecraft channels aren't registered)</param>
+        /// <returns>Whether the message was successfully sent.  False if there was a network error or if the channel wasn't registered.</returns>
+
+        protected bool SendPluginChannelMessage(string channel, byte[] data, bool sendEvenIfNotRegistered = false)
+        {
+            if (!sendEvenIfNotRegistered)
+            {
+                if (!this.registeredPluginChannels.Contains(channel))
+                {
+                    return false;
+                }
+            }
+            return Handler.SendPluginChannelMessage(channel, data, sendEvenIfNotRegistered);
         }
     }
 }

--- a/MinecraftClient/ChatBot.cs
+++ b/MinecraftClient/ChatBot.cs
@@ -75,9 +75,21 @@ namespace MinecraftClient
 
         /// <summary>
         /// Anything you want to initialize your bot, will be called on load by MinecraftCom
+        ///
+        /// NOTE: Chat messages cannot be sent at this point in the login process.  If you want to send
+        /// a message when the bot is loaded, use AfterGameJoined.
         /// </summary>
 
         public virtual void Initialize() { }
+
+        /// <summary>
+        /// Called after the server has been joined successfully and chat messages are able to be sent.
+        ///
+        /// NOTE: This is not always right after joining the server - if the bot was loaded after logging
+        /// in this is still called.
+        /// </summary>
+
+        public virtual void AfterGameJoined() { }
 
         /// <summary>
         /// Will be called every ~100ms (10fps) if loaded in MinecraftCom

--- a/MinecraftClient/McTcpClient.cs
+++ b/MinecraftClient/McTcpClient.cs
@@ -27,7 +27,16 @@ namespace MinecraftClient
 
         private readonly List<ChatBot> bots = new List<ChatBot>();
         private static readonly List<ChatBots.Script> scripts_on_hold = new List<ChatBots.Script>();
-        public void BotLoad(ChatBot b) { b.SetHandler(this); bots.Add(b); b.Initialize(); Settings.SingleCommand = ""; }
+        public void BotLoad(ChatBot b) {
+            b.SetHandler(this);
+            bots.Add(b);
+            b.Initialize();
+            if (this.handler != null)
+            {
+                b.AfterGameJoined();
+            }
+            Settings.SingleCommand = "";
+        }
         public void BotUnLoad(ChatBot b) {
             bots.RemoveAll(item => object.ReferenceEquals(item, b));
 
@@ -351,6 +360,8 @@ namespace MinecraftClient
         {
             if (!String.IsNullOrWhiteSpace(Settings.BrandInfo))
                 handler.SendBrandInfo(Settings.BrandInfo.Trim());
+            foreach (ChatBot bot in bots)
+                bot.AfterGameJoined();
         }
 
         /// <summary>

--- a/MinecraftClient/Protocol/Handlers/Protocol16.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol16.cs
@@ -164,7 +164,10 @@ namespace MinecraftClient.Protocol.Handlers
                 case 0xCF: if (protocolversion > 51) { readNextString(); readData(1); readNextString(); } readData(4); break;
                 case 0xD0: if (protocolversion > 51) { readData(1); readNextString(); } break;
                 case 0xD1: if (protocolversion > 51) { readNextTeamData(); } break;
-                case 0xFA: readNextString(); nbr = readNextShort(); readData(nbr); break;
+                case 0xFA: string channel = readNextString();
+                    byte[] payload = readNextByteArray();
+                    handler.OnPluginChannelMessage(channel, payload);
+                    break;
                 case 0xFF: string reason = readNextString();
                     handler.OnConnectionLost(ChatBot.DisconnectReason.InGameKick, reason); break;
                 default: return false; //unknown packet!

--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -303,6 +303,10 @@ namespace MinecraftClient.Protocol.Handlers
                             readNextVarShort(packetData);
                         }
                     }
+
+                    // The remaining data in the array is the entire payload of the packet.
+                    handler.OnPluginChannelMessage(channel, packetData.ToArray());
+
                     if (forgeInfo != null)
                     {
                         if (channel == "FML|HS")

--- a/MinecraftClient/Protocol/IMinecraftComHandler.cs
+++ b/MinecraftClient/Protocol/IMinecraftComHandler.cs
@@ -14,7 +14,7 @@ namespace MinecraftClient.Protocol
 
     public interface IMinecraftComHandler
     {
-        /* The MinecraftCom Hanler must
+        /* The MinecraftCom Handler must
          * provide these getters */
 
         int GetServerPort();
@@ -72,5 +72,40 @@ namespace MinecraftClient.Protocol
         /// </summary>
 
         void OnUpdate();
+
+        /// <summary>
+        /// Registers the given plugin channel for the given bot.
+        /// </summary>
+        /// <param name="channel">The channel to register.</param>
+        /// <param name="bot">The bot to register the channel for.</param>
+
+        void RegisterPluginChannel(string channel, ChatBot bot);
+
+        /// <summary>
+        /// Unregisters the given plugin channel for the given bot.
+        /// </summary>
+        /// <param name="channel">The channel to unregister.</param>
+        /// <param name="bot">The bot to unregister the channel for.</param>
+
+        void UnregisterPluginChannel(string channel, ChatBot bot);
+
+        /// <summary>
+        /// Sends a plugin channel packet to the server.  See http://wiki.vg/Plugin_channel for more information
+        /// about plugin channels.
+        /// </summary>
+        /// <param name="channel">The channel to send the packet on.</param>
+        /// <param name="data">The payload for the packet.</param>
+        /// <param name="sendEvenIfNotRegistered">Whether the packet should be sent even if the server or the client hasn't registered it yet.</param>
+        /// <returns>Whether the packet was sent: true if it was sent, false if there was a connection error or it wasn't registered.</returns>
+
+        bool SendPluginChannelMessage(string channel, byte[] data, bool sendEvenIfNotRegistered = false);
+
+        /// <summary>
+        /// Called when a plugin channel message was sent from the server.
+        /// </summary>
+        /// <param name="channel">The channel the message was sent on</param>
+        /// <param name="data">The data from the channel</param>
+
+        void OnPluginChannelMessage(string channel, byte[] data);
     }
 }


### PR DESCRIPTION
This pull request adds some methods so that ChatBots can communicate with the server using [Plugin Channels](http://wiki.vg/Plugin_channel).  It also adds a method that is called when the client has logged in as a convenient time to register the channels.