### PR TITLE
Stop attempting to read the reduced debug info value in 1.7

### DIFF
--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -250,7 +250,8 @@ namespace MinecraftClient.Protocol.Handlers
                     readNextByte(packetData);
                     readNextByte(packetData);
                     readNextString(packetData);
-                    readNextBool(packetData);
+                    if (protocolversion >= MC18Version)
+                        readNextBool(packetData);  // Reduced debug info - 1.8 and above
                     break;
                 case PacketIncomingType.ChatMessage:
                     string message = readNextString(packetData);


### PR DESCRIPTION
Fixes #165.  Reduced debug info was added in 1.8, and isn't found in 1.7.  Since it isn't there in 1.7, the client would crash when it attempts to read it on the join game packet.
