### PR TITLE
Add support for aliases in MinecraftClient.ini file

### DIFF
--- a/MinecraftClient/CSharpRunner.cs
+++ b/MinecraftClient/CSharpRunner.cs
@@ -118,8 +118,7 @@ namespace MinecraftClient
             {
                 try
                 {
-                    object compiledScript
-                        = CompileCache[scriptHash].CreateInstance("ScriptLoader.Script");
+                    object compiledScript = assembly.CreateInstance("ScriptLoader.Script");
                     return
                         compiledScript
                         .GetType()

--- a/MinecraftClient/ChatBot.cs
+++ b/MinecraftClient/ChatBot.cs
@@ -582,6 +582,28 @@ namespace MinecraftClient
         }
 
         /// <summary>
+        /// Get the current location of the player
+        /// </summary>
+        /// <returns>Minecraft world or null if associated setting is disabled</returns>
+
+        protected Mapping.Location GetCurrentLocation()
+        {
+            return Handler.GetCurrentLocation();
+        }
+
+        /// <summary>
+        /// Move to the specified location
+        /// </summary>
+        /// <param name="location">Location to reach</param>
+        /// <param name="allowUnsafe">Allow possible but unsafe locations</param>
+        /// <returns>True if a path has been found</returns>
+
+        protected bool MoveToLocation(Mapping.Location location, bool allowUnsafe = false)
+        {
+            return Handler.MoveTo(location, allowUnsafe);
+        }
+
+        /// <summary>
         /// Get a Y-M-D h:m:s timestamp representing the current system date and time
         /// </summary>
 

--- a/MinecraftClient/ChatBots/AutoRelog.cs
+++ b/MinecraftClient/ChatBots/AutoRelog.cs
@@ -68,6 +68,7 @@ namespace MinecraftClient.ChatBots
             if (Settings.AutoRelog_Enabled)
             {
                 AutoRelog bot = new AutoRelog(Settings.AutoRelog_Delay, Settings.AutoRelog_Retries);
+                bot.Initialize();
                 return bot.OnDisconnect(reason, message);
             }
             return false;

--- a/MinecraftClient/ChatBots/ChatLog.cs
+++ b/MinecraftClient/ChatBots/ChatLog.cs
@@ -53,6 +53,11 @@ namespace MinecraftClient.ChatBots
                     saveChat = false;
                     break;
             }
+            if (String.IsNullOrEmpty(file) || file.IndexOfAny(Path.GetInvalidPathChars()) >= 0)
+            {
+                LogToConsole("Path '" + file + "' contains invalid characters.");
+                UnloadBot();
+            }
         }
 
         public static MessageFilter str2filter(string filtername)

--- a/MinecraftClient/Program.cs
+++ b/MinecraftClient/Program.cs
@@ -21,9 +21,9 @@ namespace MinecraftClient
         private static McTcpClient Client;
         public static string[] startupargs;
 
-        public const string Version = "1.9.0 DEV";
+        public const string Version = "1.9.1 DEV";
         public const string MCLowestVersion = "1.4.6";
-        public const string MCHighestVersion = "1.9.0";
+        public const string MCHighestVersion = "1.9.2";
 
         private static Thread offlinePrompt = null;
         private static bool useMcVersionOnce = false;

--- a/MinecraftClient/Program.cs
+++ b/MinecraftClient/Program.cs
@@ -21,9 +21,9 @@ namespace MinecraftClient
         private static McTcpClient Client;
         public static string[] startupargs;
 
-        public const string Version = "1.9.1 DEV";
+        public const string Version = "1.10.0 DEV";
         public const string MCLowestVersion = "1.4.6";
-        public const string MCHighestVersion = "1.9.2";
+        public const string MCHighestVersion = "1.10.0";
 
         private static Thread offlinePrompt = null;
         private static bool useMcVersionOnce = false;

--- a/MinecraftClient/Protocol/Handlers/Protocol16.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol16.cs
@@ -656,10 +656,10 @@ namespace MinecraftClient.Protocol.Handlers
             catch (System.IO.IOException) { return false; }
         }
 
-        public string AutoComplete(string BehindCursor)
+        IEnumerable<string> IAutoComplete.AutoComplete(string BehindCursor)
         {
             if (String.IsNullOrEmpty(BehindCursor))
-                return "";
+                return new string[] { };
 
             byte[] autocomplete = new byte[3 + (BehindCursor.Length * 2)];
             autocomplete[0] = 0xCB;
@@ -674,8 +674,9 @@ namespace MinecraftClient.Protocol.Handlers
 
             int wait_left = 50; //do not wait more than 5 seconds (50 * 100 ms)
             while (wait_left > 0 && !autocomplete_received) { System.Threading.Thread.Sleep(100); wait_left--; }
-            string[] results = autocomplete_result.Split((char)0x00);
-            return results[0];
+            if (!String.IsNullOrEmpty(autocomplete_result) && autocomplete_received)
+                ConsoleIO.WriteLineFormatted("§8" + autocomplete_result.Replace((char)0x00, ' '), false);
+            return autocomplete_result.Split((char)0x00);
         }
 
         private static byte[] concatBytes(params byte[][] bytes)

--- a/MinecraftClient/Protocol/ProtocolHandler.cs
+++ b/MinecraftClient/Protocol/ProtocolHandler.cs
@@ -71,7 +71,7 @@ namespace MinecraftClient.Protocol
             int[] supportedVersions_Protocol16 = { 51, 60, 61, 72, 73, 74, 78 };
             if (Array.IndexOf(supportedVersions_Protocol16, ProtocolVersion) > -1)
                 return new Protocol16Handler(Client, ProtocolVersion, Handler);
-            int[] supportedVersions_Protocol18 = { 4, 5, 47, 107, 108, 109 };
+            int[] supportedVersions_Protocol18 = { 4, 5, 47, 107, 108, 109, 110 };
             if (Array.IndexOf(supportedVersions_Protocol18, ProtocolVersion) > -1)
                 return new Protocol18Handler(Client, ProtocolVersion, Handler, forgeInfo);
             throw new NotSupportedException("The protocol version no." + ProtocolVersion + " is not supported.");
@@ -131,6 +131,9 @@ namespace MinecraftClient.Protocol
                         return 108;
                     case "1.9.2":
                         return 109;
+                    case "1.9.3":
+                    case "1.9.4":
+                        return 110;
                     default:
                         return 0;
                 }

--- a/MinecraftClient/Protocol/ProtocolHandler.cs
+++ b/MinecraftClient/Protocol/ProtocolHandler.cs
@@ -71,7 +71,7 @@ namespace MinecraftClient.Protocol
             int[] supportedVersions_Protocol16 = { 51, 60, 61, 72, 73, 74, 78 };
             if (Array.IndexOf(supportedVersions_Protocol16, ProtocolVersion) > -1)
                 return new Protocol16Handler(Client, ProtocolVersion, Handler);
-            int[] supportedVersions_Protocol18 = { 4, 5, 47, 107, 108, 109, 110 };
+            int[] supportedVersions_Protocol18 = { 4, 5, 47, 107, 108, 109, 110, 210 };
             if (Array.IndexOf(supportedVersions_Protocol18, ProtocolVersion) > -1)
                 return new Protocol18Handler(Client, ProtocolVersion, Handler, forgeInfo);
             throw new NotSupportedException("The protocol version no." + ProtocolVersion + " is not supported.");
@@ -134,6 +134,8 @@ namespace MinecraftClient.Protocol
                     case "1.9.3":
                     case "1.9.4":
                         return 110;
+                    case "1.10.0":
+                        return 210;
                     default:
                         return 0;
                 }

--- a/MinecraftClient/Protocol/ProtocolHandler.cs
+++ b/MinecraftClient/Protocol/ProtocolHandler.cs
@@ -71,7 +71,7 @@ namespace MinecraftClient.Protocol
             int[] supportedVersions_Protocol16 = { 51, 60, 61, 72, 73, 74, 78 };
             if (Array.IndexOf(supportedVersions_Protocol16, ProtocolVersion) > -1)
                 return new Protocol16Handler(Client, ProtocolVersion, Handler);
-            int[] supportedVersions_Protocol18 = { 4, 5, 47, 107, 108 };
+            int[] supportedVersions_Protocol18 = { 4, 5, 47, 107, 108, 109 };
             if (Array.IndexOf(supportedVersions_Protocol18, ProtocolVersion) > -1)
                 return new Protocol18Handler(Client, ProtocolVersion, Handler, forgeInfo);
             throw new NotSupportedException("The protocol version no." + ProtocolVersion + " is not supported.");
@@ -128,8 +128,9 @@ namespace MinecraftClient.Protocol
                     case "1.9.0":
                         return 107;
                     case "1.9.1":
-                    case "1.9.2":
                         return 108;
+                    case "1.9.2":
+                        return 109;
                     default:
                         return 0;
                 }

--- a/MinecraftClient/Protocol/ProtocolHandler.cs
+++ b/MinecraftClient/Protocol/ProtocolHandler.cs
@@ -71,7 +71,7 @@ namespace MinecraftClient.Protocol
             int[] supportedVersions_Protocol16 = { 51, 60, 61, 72, 73, 74, 78 };
             if (Array.IndexOf(supportedVersions_Protocol16, ProtocolVersion) > -1)
                 return new Protocol16Handler(Client, ProtocolVersion, Handler);
-            int[] supportedVersions_Protocol18 = { 4, 5, 47, 107 };
+            int[] supportedVersions_Protocol18 = { 4, 5, 47, 107, 108 };
             if (Array.IndexOf(supportedVersions_Protocol18, ProtocolVersion) > -1)
                 return new Protocol18Handler(Client, ProtocolVersion, Handler, forgeInfo);
             throw new NotSupportedException("The protocol version no." + ProtocolVersion + " is not supported.");
@@ -127,6 +127,9 @@ namespace MinecraftClient.Protocol
                         return 47;
                     case "1.9.0":
                         return 107;
+                    case "1.9.1":
+                    case "1.9.2":
+                        return 108;
                     default:
                         return 0;
                 }

--- a/MinecraftClient/Settings.cs
+++ b/MinecraftClient/Settings.cs
@@ -136,7 +136,10 @@ namespace MinecraftClient
                     ParseMode pMode = ParseMode.Default;
                     foreach (string lineRAW in Lines)
                     {
-                        string line = lineRAW.Split('#')[0].Trim();
+                        string line = pMode == ParseMode.Main && lineRAW.ToLower().Trim().StartsWith("password")
+                            ? lineRAW.Trim() //Do not strip # in passwords
+                            : lineRAW.Split('#')[0].Trim();
+
                         if (line.Length > 0)
                         {
                             if (line[0] == '[' && line[line.Length - 1] == ']')

--- a/MinecraftClient/Settings.cs
+++ b/MinecraftClient/Settings.cs
@@ -132,8 +132,7 @@ namespace MinecraftClient
             {
                 try
                 {
-                    string serverIP = "";
-                    string login = "";
+                    string serverAlias = "";
                     string[] Lines = File.ReadAllLines(settingsfile);
                     ParseMode pMode = ParseMode.Default;
                     foreach (string lineRAW in Lines)
@@ -174,9 +173,9 @@ namespace MinecraftClient
                                         case ParseMode.Main:
                                             switch (argName.ToLower())
                                             {
-                                                case "login": login = argValue; Login = argValue; break;
+                                                case "login": Login = argValue; break;
                                                 case "password": Password = argValue; break;
-                                                case "serverip": serverIP = argValue; SetServerIP(argValue); break;
+                                                case "serverip": if(!SetServerIP(argValue)) serverAlias = argValue; ; break;
                                                 case "singlecommand": SingleCommand = argValue; break;
                                                 case "language": Language = argValue; break;
                                                 case "consoletitle": ConsoleTitle = argValue; break;
@@ -228,7 +227,7 @@ namespace MinecraftClient
                                                         }
 
                                                         //Try user value against aliases after load
-                                                        Settings.SetAccount(login);
+                                                        Settings.SetAccount(Login);
                                                     }
                                                     break;
 
@@ -257,7 +256,7 @@ namespace MinecraftClient
                                                         ServerPort = server_port_temp;
 
                                                         //Try server value against aliases after load
-                                                        SetServerIP(serverIP);
+                                                        SetServerIP(serverAlias);
                                                     }
                                                     break;
 

--- a/MinecraftClient/Settings.cs
+++ b/MinecraftClient/Settings.cs
@@ -132,6 +132,8 @@ namespace MinecraftClient
             {
                 try
                 {
+                    string serverIP = "";
+                    string login = "";
                     string[] Lines = File.ReadAllLines(settingsfile);
                     ParseMode pMode = ParseMode.Default;
                     foreach (string lineRAW in Lines)
@@ -172,9 +174,9 @@ namespace MinecraftClient
                                         case ParseMode.Main:
                                             switch (argName.ToLower())
                                             {
-                                                case "login": Login = argValue; break;
+                                                case "login": login = argValue; Login = argValue; break;
                                                 case "password": Password = argValue; break;
-                                                case "serverip": SetServerIP(argValue); break;
+                                                case "serverip": serverIP = argValue; SetServerIP(argValue); break;
                                                 case "singlecommand": SingleCommand = argValue; break;
                                                 case "language": Language = argValue; break;
                                                 case "consoletitle": ConsoleTitle = argValue; break;
@@ -224,6 +226,9 @@ namespace MinecraftClient
                                                                 Accounts[account_data[0].ToLower()]
                                                                     = new KeyValuePair<string, string>(account_data[1], account_data[2]);
                                                         }
+
+                                                        //Try user value against aliases after load
+                                                        Settings.SetAccount(login);
                                                     }
                                                     break;
 
@@ -250,6 +255,9 @@ namespace MinecraftClient
                                                         //Restore current server info
                                                         ServerIP = server_host_temp;
                                                         ServerPort = server_port_temp;
+
+                                                        //Try server value against aliases after load
+                                                        SetServerIP(serverIP);
                                                     }
                                                     break;
 

--- a/MinecraftClient/config/README.txt
+++ b/MinecraftClient/config/README.txt
@@ -112,7 +112,7 @@ If you are experienced with C#, you may also write a C# script.
 That's a bit more involved, but way more powerful than regular scripts.
 You can look to the provided sample C# scripts for getting started.
 
-C# scripts can be used for creating your own ChatBot without recompiling the wole project.
+C# scripts can be used for creating your own ChatBot without recompiling the whole project.
 These bots are embedded in a script file, which is compiled and loaded on the fly.
 ChatBots can access plugin channels for communicating with your own plugin.
 

--- a/MinecraftClient/config/README.txt
+++ b/MinecraftClient/config/README.txt
@@ -16,6 +16,7 @@ First, extract the archive if not already extracted.
 On Windows, simply open MinecraftClient.exe by double-clicking on it.
 On Mac or Linux, open a terminal in this folder and run "mono MinecraftClient.exe".
 If you cannot authenticate on Mono, you'll need to run "mozroots --import --ask-remove" once.
+If Mono crashes, retry with mono-complete, not mono-runtime. Mono v4.0 to 4.2 is recommended.
 
 ===========================================
  Using Configuration files & Enabling bots


### PR DESCRIPTION
Closed previous pull request because it needed to be cleaned up. Login and ServerIP will be checked against alias files when they are loaded.