### PR TITLE
Add 1.11 support

### DIFF
--- a/MinecraftClient/Program.cs
+++ b/MinecraftClient/Program.cs
@@ -20,9 +20,9 @@ namespace MinecraftClient
         private static McTcpClient Client;
         public static string[] startupargs;
 
-        public const string Version = "1.10.0 DEV";
+        public const string Version = "1.11.0 DEV";
         public const string MCLowestVersion = "1.4.6";
-        public const string MCHighestVersion = "1.10.2";
+        public const string MCHighestVersion = "1.11.0";
 
         private static Thread offlinePrompt = null;
         private static bool useMcVersionOnce = false;

--- a/MinecraftClient/Protocol/ProtocolHandler.cs
+++ b/MinecraftClient/Protocol/ProtocolHandler.cs
@@ -108,7 +108,7 @@ namespace MinecraftClient.Protocol
             int[] supportedVersions_Protocol16 = { 51, 60, 61, 72, 73, 74, 78 };
             if (Array.IndexOf(supportedVersions_Protocol16, ProtocolVersion) > -1)
                 return new Protocol16Handler(Client, ProtocolVersion, Handler);
-            int[] supportedVersions_Protocol18 = { 4, 5, 47, 107, 108, 109, 110, 210 };
+            int[] supportedVersions_Protocol18 = { 4, 5, 47, 107, 108, 109, 110, 210, 315 };
             if (Array.IndexOf(supportedVersions_Protocol18, ProtocolVersion) > -1)
                 return new Protocol18Handler(Client, ProtocolVersion, Handler, forgeInfo);
             throw new NotSupportedException("The protocol version no." + ProtocolVersion + " is not supported.");
@@ -178,6 +178,9 @@ namespace MinecraftClient.Protocol
                     case "1.10.1":
                     case "1.10.2":
                         return 210;
+                    case "1.11":
+                    case "1.11.0":
+                        return 315;
                     default:
                         return 0;
                 }


### PR DESCRIPTION
1.11 made no protocol changes that should affect this project ([here's the pre-release protocol page](http://wiki.vg/index.php?title=Pre-release_protocol&oldid=8249)).

Well, there is actually one change that _may_ affect it - the [Title packet](http://wiki.vg/index.php?title=Pre-release_protocol&oldid=8249#Title) now supports writing to the action bar just as the chat message packet does.  I didn't implement that, since the title packet is somewhat complicated, but it shouldn't cause any issues (I'm 99% certain that the chat message variant is still the primary variant used in-game, but I haven't fully checked).