### PR TITLE
Fix packet compression (+ 1 more)

### DIFF
--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -1421,12 +1421,10 @@ namespace MinecraftClient.Protocol.Handlers
 
             if (compression_treshold > 0) //Compression enabled?
             {
-                if (the_packet.Length > compression_treshold) //Packet long enough for compressing?
+                if (the_packet.Length >= compression_treshold) //Packet long enough for compressing?
                 {
-                    byte[] uncompressed_length = getVarInt(the_packet.Length);
                     byte[] compressed_packet = ZlibUtils.Compress(the_packet);
-                    byte[] compressed_packet_length = getVarInt(compressed_packet.Length);
-                    the_packet = concatBytes(compressed_packet_length, compressed_packet);
+                    the_packet = concatBytes(getVarInt(the_packet.Length), compressed_packet);
                 }
                 else
                 {

--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -292,7 +292,8 @@ namespace MinecraftClient.Protocol.Handlers
             PluginMessage,
             TabComplete,
             PlayerPosition,
-            PlayerPositionAndLook
+            PlayerPositionAndLook,
+            TeleportConfirm
         }
 
         /// <summary>
@@ -316,6 +317,7 @@ namespace MinecraftClient.Protocol.Handlers
                     case PacketOutgoingType.TabComplete: return 0x14;
                     case PacketOutgoingType.PlayerPosition: return 0x04;
                     case PacketOutgoingType.PlayerPositionAndLook: return 0x06;
+                    case PacketOutgoingType.TeleportConfirm: throw new InvalidOperationException("Teleport confirm is not supported in protocol " + protocol);
                 }
             }
             else if (protocol < MC17w13aVersion)
@@ -331,6 +333,7 @@ namespace MinecraftClient.Protocol.Handlers
                     case PacketOutgoingType.TabComplete: return 0x01;
                     case PacketOutgoingType.PlayerPosition: return 0x0C;
                     case PacketOutgoingType.PlayerPositionAndLook: return 0x0D;
+                    case PacketOutgoingType.TeleportConfirm: return 0x00;
                 }
             }
             else if (protocolversion < MC112pre5Version)
@@ -346,6 +349,7 @@ namespace MinecraftClient.Protocol.Handlers
                     case PacketOutgoingType.TabComplete: return 0x02;
                     case PacketOutgoingType.PlayerPosition: return 0x0D;
                     case PacketOutgoingType.PlayerPositionAndLook: return 0x0E;
+                    case PacketOutgoingType.TeleportConfirm: return 0x00;
                 }
             }
             else if (protocol < MC17w31aVersion)
@@ -361,6 +365,7 @@ namespace MinecraftClient.Protocol.Handlers
                     case PacketOutgoingType.TabComplete: return 0x02;
                     case PacketOutgoingType.PlayerPosition: return 0x0E;
                     case PacketOutgoingType.PlayerPositionAndLook: return 0x0F;
+                    case PacketOutgoingType.TeleportConfirm: return 0x00;
                 }
             }
             else
@@ -376,6 +381,7 @@ namespace MinecraftClient.Protocol.Handlers
                     case PacketOutgoingType.TabComplete: return 0x01;
                     case PacketOutgoingType.PlayerPosition: return 0x0D;
                     case PacketOutgoingType.PlayerPositionAndLook: return 0x0E;
+                    case PacketOutgoingType.TeleportConfirm: return 0x00;
                 }
             }
 
@@ -459,13 +465,13 @@ namespace MinecraftClient.Protocol.Handlers
                             handler.UpdateLocation(location, yawpitch);
                         }
                         else handler.UpdateLocation(new Location(x, y, z), yawpitch);
+                    }
 
-                        if (protocolversion >= MC19Version)
-                        {
-                            int teleportID = readNextVarInt(packetData);
-                            // Teleport confirm packet
-                            SendPacket(0x00, getVarInt(teleportID));
-                        }
+                    if (protocolversion >= MC19Version)
+                    {
+                        int teleportID = readNextVarInt(packetData);
+                        // Teleport confirm packet
+                        SendPacket(PacketOutgoingType.TeleportConfirm, getVarInt(teleportID));
                     }
                     break;
                 case PacketIncomingType.ChunkData:

--- a/MinecraftClient/Protocol/Handlers/ZlibUtils.cs
+++ b/MinecraftClient/Protocol/Handlers/ZlibUtils.cs
@@ -21,17 +21,16 @@ namespace MinecraftClient.Protocol.Handlers
         /// <returns>Compressed data as a byte array</returns>
         public static byte[] Compress(byte[] to_compress)
         {
-            ZlibStream stream = new ZlibStream(new System.IO.MemoryStream(to_compress, false), CompressionMode.Compress);
-            List<byte> temp_compression_list = new List<byte>();
-            byte[] b = new byte[1];
-            while (true)
+            byte[] data;
+            using (System.IO.MemoryStream memstream = new System.IO.MemoryStream())
             {
-                int read = stream.Read(b, 0, 1);
-                if (read > 0) { temp_compression_list.Add(b[0]); }
-                else break;
+                using (ZlibStream stream = new ZlibStream(memstream, CompressionMode.Compress))
+                {
+                    stream.Write(to_compress, 0, to_compress.Length);
+                }
+                data = memstream.ToArray();
             }
-            stream.Close();
-            return temp_compression_list.ToArray();
+            return data;
         }
 
         /// <summary>


### PR DESCRIPTION
This PR does two things:

* Fixes packet compression when MCC is encoding packets.  Broken packet compression was what was causing MCC to connect to forge servers - a large outbound packet was being sent (the mod list), and that failed to compress correctly.  (I'm not entirely sure why I never had any problems with this before during the first set of forge tests, not to mention that this hasn't ever caused problems elsewhere)

    There were 3 problems:

    1. The compression threshold was compared with `>` when it should have been `>=`.  This didn't cause major problems since it's a rare case.
    2. The compressed packet length was being used when the uncompressed length should have been used.  This broke things severely, but not as much as the next problem:
    3. Only 2 or so bytes of compressed data would ever be sent, due to `ZlibUtils.Compress` being implemented strangely.  That implementation only filled the buffer once or twice (and changing to `ReadByte` still had the same issue).  Writing to a memory stream worked correctly, and now compressed data is actually sent.

*  Stops hardcoding the ID of TeleportConfirm. This was a change that I made earlier but never pushed, and I'm just including it here to get it out.  Always sending the teleport confirm packet even when terrain and movements is disabled is simply needed to ensure proper server behavior (it's minor, and I can't easily give examples of what would happen if not done, but it is still needed).