### PR TITLE
Switch console window encoding to Unicode

### DIFF
--- a/MinecraftClient/Program.cs
+++ b/MinecraftClient/Program.cs
@@ -45,9 +45,9 @@ namespace MinecraftClient
             if (args.Length >= 1 && args[args.Length - 1] == "BasicIO")
             {
                 ConsoleIO.basicIO = true;
-                Console.OutputEncoding = Console.InputEncoding = Encoding.UTF8;
                 args = args.Where(o => !Object.ReferenceEquals(o, args[args.Length - 1])).ToArray();
             }
+            Console.OutputEncoding = Console.InputEncoding = Encoding.UTF8;
 
             //Process ini configuration file
             if (args.Length >= 1 && System.IO.File.Exists(args[0]) && System.IO.Path.GetExtension(args[0]).ToLower() == ".ini")

--- a/MinecraftClient/Program.cs
+++ b/MinecraftClient/Program.cs
@@ -45,7 +45,7 @@ namespace MinecraftClient
             if (args.Length >= 1 && args[args.Length - 1] == "BasicIO")
             {
                 ConsoleIO.basicIO = true;
-                Console.OutputEncoding = Console.InputEncoding = Encoding.GetEncoding(System.Globalization.CultureInfo.CurrentCulture.TextInfo.ANSICodePage);
+                Console.OutputEncoding = Console.InputEncoding = Encoding.UTF8;
                 args = args.Where(o => !Object.ReferenceEquals(o, args[args.Length - 1])).ToArray();
             }
 


### PR DESCRIPTION
Unicode characters are becoming quite common within minecraft servers (especially the large ones) nowadays. As of now MCC creates a System beep every single time one of these characters are processed by ConsoleIO. 

I'm no expert in C#, so I'm unsure if ANSI is required for anything, but I've been perfectly fine with UTF-8 so far.

(I'm still not very familiar with github so apologies if theres a duplicate of this request)