### PR TITLE
Add support for 1.12.2

### DIFF
--- a/MinecraftClient/Program.cs
+++ b/MinecraftClient/Program.cs
@@ -20,9 +20,9 @@ namespace MinecraftClient
         private static McTcpClient Client;
         public static string[] startupargs;
 
-        public const string Version = "1.12.1 DEV";
+        public const string Version = "1.12.2 DEV";
         public const string MCLowestVersion = "1.4.6";
-        public const string MCHighestVersion = "1.12.1";
+        public const string MCHighestVersion = "1.12.2";
 
         private static Thread offlinePrompt = null;
         private static bool useMcVersionOnce = false;

--- a/MinecraftClient/Protocol/ProtocolHandler.cs
+++ b/MinecraftClient/Protocol/ProtocolHandler.cs
@@ -106,7 +106,7 @@ namespace MinecraftClient.Protocol
             int[] supportedVersions_Protocol16 = { 51, 60, 61, 72, 73, 74, 78 };
             if (Array.IndexOf(supportedVersions_Protocol16, ProtocolVersion) > -1)
                 return new Protocol16Handler(Client, ProtocolVersion, Handler);
-            int[] supportedVersions_Protocol18 = { 4, 5, 47, 107, 108, 109, 110, 210, 315, 316, 335, 338 };
+            int[] supportedVersions_Protocol18 = { 4, 5, 47, 107, 108, 109, 110, 210, 315, 316, 335, 338, 340 };
             if (Array.IndexOf(supportedVersions_Protocol18, ProtocolVersion) > -1)
                 return new Protocol18Handler(Client, ProtocolVersion, Handler, forgeInfo);
             throw new NotSupportedException("The protocol version no." + ProtocolVersion + " is not supported.");
@@ -187,6 +187,8 @@ namespace MinecraftClient.Protocol
                         return 335;
                     case "1.12.1":
                         return 338;
+                    case "1.12.2":
+                        return 340;
                     default:
                         return 0;
                 }


### PR DESCRIPTION
While there are protocol changes to the keep alive packet, the way MCC implements it (sending the same bytes to the server) should mean that the changes do not affect us.