### PR TITLE
GetPing AutoTimeout timeout delay change.

### DIFF
--- a/MinecraftClient/Protocol/ProtocolHandler.cs
+++ b/MinecraftClient/Protocol/ProtocolHandler.cs
@@ -80,7 +80,7 @@ namespace MinecraftClient.Protocol
                 {
                     ConsoleIO.WriteLineFormatted(String.Format("§8{0}: {1}", e.GetType().FullName, e.Message));
                 }
-            }, TimeSpan.FromSeconds(Settings.ResolveSrvRecordsShortTimeout ? 5 : 30)))
+            }, TimeSpan.FromSeconds(Settings.ResolveSrvRecordsShortTimeout ? 10 : 30)))
             {
                 protocolversion = protocolversionTmp;
                 forgeInfo = forgeInfoTmp;


### PR DESCRIPTION
Increase the time of the fast srvrecord setting from 5 to 10 seconds. As of now the method gets timed out before actually completing/attempting the Protocol18 DoPing causing auto to fail on most servers.