### PR TITLE
#729: allow to use GetServerPort/GetServerHost/GetUsername/GetUserUUID in MCC scripts

### DIFF
--- a/MinecraftClient/ChatBot.cs
+++ b/MinecraftClient/ChatBot.cs
@@ -669,6 +669,42 @@ namespace MinecraftClient
         }
 
         /// <summary>
+        /// Return the Server Port where the client is connected to
+        /// </summary>
+        /// <returns>Server Port where the client is connected to</returns>
+        protected int GetServerPort()
+        {
+            return Handler.GetServerPort();
+        }
+
+        /// <summary>
+        /// Return the Server Host where the client is connected to
+        /// </summary>
+        /// <returns>Server Host where the client is connected to</returns>
+        protected string GetServerHost()
+        {
+            return Handler.GetServerHost();
+        }
+
+        /// <summary>
+        /// Return the Username of the current account
+        /// </summary>
+        /// <returns>Username of the current account</returns>
+        protected string GetUsername()
+        {
+            return Handler.GetUsername();
+        }
+
+        /// <summary>
+        /// Return the UserUUID of the current account
+        /// </summary>
+        /// <returns>UserUUID of the current account</returns>
+        protected string GetUserUUID()
+        {
+            return Handler.GetUserUUID();
+        }
+
+        /// <summary>
         /// Return the list of currently online players
         /// </summary>
         /// <returns>List of online players</returns>

--- a/MinecraftClient/Settings.cs
+++ b/MinecraftClient/Settings.cs
@@ -162,6 +162,7 @@ namespace MinecraftClient
         /// <param name="settingsfile">File to load</param>
         public static void LoadSettings(string settingsfile)
         {
+            ConsoleIO.WriteLogLine(String.Format("[Settings] Loading Settings from {0}", System.IO.Path.GetFullPath(settingsfile)));
             if (File.Exists(settingsfile))
             {
                 try


### PR DESCRIPTION
Related to https://github.com/ORelio/Minecraft-Console-Client/issues/729

This MR allow to use GetServerPort/GetServerHost/GetUsername/GetUserUUID in MCC scripts

Note I left out  `GetSessionID` since I feel this should not be exposed to a MCC script