### PR TITLE
#427: Fix TriggerOnLogin doesn't work when /reco

### DIFF
--- a/MinecraftClient/ChatBot.cs
+++ b/MinecraftClient/ChatBot.cs
@@ -663,7 +663,7 @@ namespace MinecraftClient
             }
             else
             {
-                LogToConsole("File not found: " + Settings.Alerts_MatchesFile);
+                LogToConsole("File not found: " + System.IO.Path.GetFullPath(file));
                 return new string[0];
             }
         }

--- a/MinecraftClient/ChatBots/AutoRelog.cs
+++ b/MinecraftClient/ChatBots/AutoRelog.cs
@@ -36,7 +36,7 @@ namespace MinecraftClient.ChatBots
             if (System.IO.File.Exists(Settings.AutoRelog_KickMessagesFile))
             {
                 if (Settings.DebugMessages)
-                    LogToConsole("Loading messages from file: " + Settings.AutoRelog_KickMessagesFile);
+                    LogToConsole("Loading messages from file: " + System.IO.Path.GetFullPath(Settings.AutoRelog_KickMessagesFile));
 
                 dictionary = System.IO.File.ReadAllLines(Settings.AutoRelog_KickMessagesFile);
 
@@ -49,7 +49,7 @@ namespace MinecraftClient.ChatBots
             }
             else
             {
-                LogToConsole("File not found: " + Settings.AutoRelog_KickMessagesFile);
+                LogToConsole("File not found: " + System.IO.Path.GetFullPath(Settings.AutoRelog_KickMessagesFile));
 
                 if (Settings.DebugMessages)
                     LogToConsole("  Current directory was: " + System.IO.Directory.GetCurrentDirectory());

--- a/MinecraftClient/ChatBots/AutoRespond.cs
+++ b/MinecraftClient/ChatBots/AutoRespond.cs
@@ -132,6 +132,9 @@ namespace MinecraftClient.ChatBots
                 bool ownersOnly = false;
                 respondRules = new List<RespondRule>();
 
+                if (Settings.DebugMessages)
+                    LogToConsole("Loading matches from file: " + System.IO.Path.GetFullPath(matchesFile));
+
                 foreach (string lineRAW in File.ReadAllLines(matchesFile))
                 {
                     string line = lineRAW.Split('#')[0].Trim();
@@ -175,7 +178,7 @@ namespace MinecraftClient.ChatBots
             }
             else
             {
-                LogToConsole("File not found: '" + matchesFile + "'");
+                LogToConsole("File not found: '" + System.IO.Path.GetFullPath(matchesFile) + "'");
                 UnloadBot(); //No need to keep the bot active
             }
         }

--- a/MinecraftClient/ChatBots/Script.cs
+++ b/MinecraftClient/ChatBots/Script.cs
@@ -140,7 +140,7 @@ namespace MinecraftClient.ChatBots
             }
             else
             {
-                LogToConsole("File not found: '" + file + "'");
+                LogToConsole("File not found: '" + System.IO.Path.GetFullPath(file) + "'");
 
                 if (owner != null)
                     SendPrivateMessage(owner, "File not found: '" + file + "'");

--- a/MinecraftClient/ChatBots/ScriptScheduler.cs
+++ b/MinecraftClient/ChatBots/ScriptScheduler.cs
@@ -45,7 +45,7 @@ namespace MinecraftClient.ChatBots
             if (System.IO.File.Exists(tasksfile))
             {
                 if (Settings.DebugMessages)
-                    LogToConsole("Loading tasks from '" + tasksfile + "'");
+                    LogToConsole("Loading tasks from '" + System.IO.Path.GetFullPath(tasksfile) + "'");
                 TaskDesc current_task = null;
                 String[] lines = System.IO.File.ReadAllLines(tasksfile);
                 foreach (string lineRAW in lines)
@@ -87,7 +87,7 @@ namespace MinecraftClient.ChatBots
             }
             else
             {
-                LogToConsole("File not found: '" + tasksfile + "'");
+                LogToConsole("File not found: '" + System.IO.Path.GetFullPath(tasksfile) + "'");
                 UnloadBot(); //No need to keep the bot active
             }
         }

--- a/MinecraftClient/McTcpClient.cs
+++ b/MinecraftClient/McTcpClient.cs
@@ -354,6 +354,9 @@ namespace MinecraftClient
         /// </summary>
         public void Disconnect()
         {
+            foreach (ChatBot bot in bots)
+                bot.OnDisconnect(ChatBot.DisconnectReason.ConnectionLost, "Disconnected");
+
             botsOnHold.Clear();
             botsOnHold.AddRange(bots);
 

--- a/MinecraftClient/Settings.cs
+++ b/MinecraftClient/Settings.cs
@@ -462,13 +462,20 @@ namespace MinecraftClient
                                                     }
                                                     break;
                                                 case "renderdistance":
-                                                    MCSettings_RenderDistance = (byte)str2int(argValue);
-                                                    switch (argValue.ToLower())
+                                                    MCSettings_RenderDistance = 2;
+                                                    if (argValue.All(Char.IsDigit))
                                                     {
-                                                        case "tiny": MCSettings_RenderDistance = 2; break;
-                                                        case "short": MCSettings_RenderDistance = 4; break;
-                                                        case "medium": MCSettings_RenderDistance = 8; break;
-                                                        case "far": MCSettings_RenderDistance = 16; break;
+                                                        MCSettings_RenderDistance = (byte)str2int(argValue);
+                                                    }
+                                                    else
+                                                    {
+                                                        switch (argValue.ToLower())
+                                                        {
+                                                            case "tiny": MCSettings_RenderDistance = 2; break;
+                                                            case "short": MCSettings_RenderDistance = 4; break;
+                                                            case "medium": MCSettings_RenderDistance = 8; break;
+                                                            case "far": MCSettings_RenderDistance = 16; break;
+                                                        }
                                                     }
                                                     break;
                                                 case "chatmode":

--- a/MinecraftClient/Settings.cs
+++ b/MinecraftClient/Settings.cs
@@ -641,9 +641,12 @@ namespace MinecraftClient
         {
             try
             {
-                return Convert.ToInt32(str);
+                return Convert.ToInt32(str.Trim());
             }
-            catch { return 0; }
+            catch {
+                ConsoleIO.WriteLogLine("Failed to convert '" + str + "' into an int. Please check your settings.");
+                return 0;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This MR mainly fixes https://github.com/ORelio/Minecraft-Console-Client/issues/427 and also includes some minor improvements around when a specific config file could not be found (in particular reports the full path to the filename).

I have tested the changes via:
MinecraftClient.ini
```
[ScriptScheduler]
enabled=true
tasksfile=tasks.ini
```

tasks.ini:
```
[Task]
TriggerOnLogin=true
script=loginscript.txt
```

loginscript.txt
```
wait 10
send Hello From task
```