### PR TITLE
Add debugging to var int to big

### DIFF
--- a/MinecraftClient/ChatBot.cs
+++ b/MinecraftClient/ChatBot.cs
@@ -535,7 +535,7 @@ namespace MinecraftClient
         /// Disconnect from the server and restart the program
         /// It will unload and reload all the bots and then reconnect to the server
         /// </summary>
-        /// <param name="attempts">In case of failure, maximum extra attempts before aborting</param>
+        /// <param name="ExtraAttempts">In case of failure, maximum extra attempts before aborting</param>
         /// <param name="delaySeconds">Optional delay, in seconds, before restarting</param>
         protected void ReconnectToTheServer(int ExtraAttempts = 3, int delaySeconds = 0)
         {

--- a/MinecraftClient/ConsoleIO.cs
+++ b/MinecraftClient/ConsoleIO.cs
@@ -312,7 +312,7 @@ namespace MinecraftClient
         /// </summary>
         /// <param name="str">String to write</param>
         /// <param name="acceptnewlines">If false, space are printed instead of newlines</param>
-        /// <param name="displayTimestamps">
+        /// <param name="displayTimestamp">
         /// If false, no timestamp is prepended.
         /// If true, "hh-mm-ss" timestamp will be prepended.
         /// If unspecified, value is retrieved from EnableTimestamps.

--- a/MinecraftClient/Crypto/CryptoHandler.cs
+++ b/MinecraftClient/Crypto/CryptoHandler.cs
@@ -16,7 +16,7 @@ namespace MinecraftClient.Crypto
         /// <summary>
         /// Get a cryptographic service for encrypting data using the server's RSA public key
         /// </summary>
-        /// <param name="key">Byte array containing the encoded key</param>
+        /// <param name="x509key">Byte array containing the encoded key</param>
         /// <returns>Returns the corresponding RSA Crypto Service</returns>
 
         public static RSACryptoServiceProvider DecodeRSAPublicKey(byte[] x509key)

--- a/MinecraftClient/McTcpClient.cs
+++ b/MinecraftClient/McTcpClient.cs
@@ -287,7 +287,6 @@ namespace MinecraftClient
         /// Perform an internal MCC command (not a server command, use SendText() instead for that!)
         /// </summary>
         /// <param name="command">The command</param>
-        /// <param name="interactive_mode">Set to true if command was sent by the user using the command prompt</param>
         /// <param name="response_msg">May contain a confirmation or error message after processing the command, or "" otherwise.</param>
         /// <returns>TRUE if the command was indeed an internal MCC command</returns>
         public bool PerformInternalCommand(string command, ref string response_msg)
@@ -565,7 +564,7 @@ namespace MinecraftClient
         /// or if a ChatBot whishes to update the player's location.
         /// </summary>
         /// <param name="location">The new location</param>
-        /// <param name="lookAt">Block coordinates to look at</param>
+        /// <param name="lookAtLocation">Block coordinates to look at</param>
         public void UpdateLocation(Location location, Location lookAtLocation)
         {
             double dx = lookAtLocation.X - (location.X - 0.5);
@@ -640,7 +639,6 @@ namespace MinecraftClient
         /// </summary>
         /// <param name="text">Text received</param>
         /// <param name="isJson">TRUE if the text is JSON-Encoded</param>
-        /// <param name="links">Links embedded in text</param>
         public void OnTextReceived(string text, bool isJson)
         {
             lock (lastKeepAliveLock)

--- a/MinecraftClient/Protocol/Handlers/DataTypes.cs
+++ b/MinecraftClient/Protocol/Handlers/DataTypes.cs
@@ -267,6 +267,7 @@ namespace MinecraftClient.Protocol.Handlers
         /// <returns>The integer</returns>
         public int ReadNextVarInt(List<byte> cache)
         {
+            string rawData = BitConverter.ToString(cache.ToArray());
             int i = 0;
             int j = 0;
             int k = 0;
@@ -274,7 +275,7 @@ namespace MinecraftClient.Protocol.Handlers
             {
                 k = ReadNextByte(cache);
                 i |= (k & 0x7F) << j++ * 7;
-                if (j > 5) throw new OverflowException("VarInt too big");
+                if (j > 5) throw new OverflowException("VarInt too big " + rawData);
                 if ((k & 0x80) != 128) break;
             }
             return i;

--- a/MinecraftClient/Protocol/Handlers/Protocol18Forge.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18Forge.cs
@@ -25,8 +25,8 @@ namespace MinecraftClient.Protocol.Handlers
         /// Initialize a new Forge protocol handler
         /// </summary>
         /// <param name="forgeInfo">Forge Server Information</param>
-        /// <param name="protocolversion">Minecraft protocol version</param>
-        /// <param name="datatypes">Minecraft data types handler</param>
+        /// <param name="protocolVersion">Minecraft protocol version</param>
+        /// <param name="dataTypes">Minecraft data types handler</param>
         public Protocol18Forge(ForgeInfo forgeInfo, int protocolVersion, DataTypes dataTypes, Protocol18Handler protocol18, IMinecraftComHandler mcHandler)
         {
             this.forgeInfo = forgeInfo;
@@ -102,7 +102,7 @@ namespace MinecraftClient.Protocol.Handlers
         /// </summary>
         /// <param name="channel">Plugin message channel</param>
         /// <param name="packetData">Plugin message data</param>
-        /// <param name="currentdimension">Current world dimension</param>
+        /// <param name="currentDimension">Current world dimension</param>
         /// <returns>TRUE if the plugin message was recognized and handled</returns>
         public bool HandlePluginMessage(string channel, List<byte> packetData, ref int currentDimension)
         {

--- a/MinecraftClient/Protocol/IMinecraftCom.cs
+++ b/MinecraftClient/Protocol/IMinecraftCom.cs
@@ -25,7 +25,6 @@ namespace MinecraftClient.Protocol
         /// <summary>
         /// Disconnect from the server
         /// </summary>
-        /// <param name="message">Reason</param>
         void Disconnect();
 
         /// <summary>


### PR DESCRIPTION
This MR mainly adds an additional reporting when we encounter the `VarInt too big` issue. Note that there is also a `ReadNextVarIntRAW` where I haven't added the same since it does not seem to be the place where we encounter the exception.

Also fixed some Doc-Strings ;)