### PR TITLE
Fix VarInt too big for player position and look

### DIFF
--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -226,15 +226,16 @@ namespace MinecraftClient.Protocol.Handlers
                         handler.OnRespawn();
                         break;
                     case PacketIncomingType.PlayerPositionAndLook:
+                        // These always need to be read, since we need the field after them for teleport confirm
+                        double x = dataTypes.ReadNextDouble(packetData);
+                        double y = dataTypes.ReadNextDouble(packetData);
+                        double z = dataTypes.ReadNextDouble(packetData);
+                        float yaw = dataTypes.ReadNextFloat(packetData);
+                        float pitch = dataTypes.ReadNextFloat(packetData);
+                        byte locMask = dataTypes.ReadNextByte(packetData);
+
                         if (handler.GetTerrainEnabled())
                         {
-                            double x = dataTypes.ReadNextDouble(packetData);
-                            double y = dataTypes.ReadNextDouble(packetData);
-                            double z = dataTypes.ReadNextDouble(packetData);
-                            float yaw = dataTypes.ReadNextFloat(packetData);
-                            float pitch = dataTypes.ReadNextFloat(packetData);
-                            byte locMask = dataTypes.ReadNextByte(packetData);
-
                             if (protocolversion >= MC18Version)
                             {
                                 Location location = handler.GetCurrentLocation();


### PR DESCRIPTION
See https://github.com/ORelio/Minecraft-Console-Client/issues/811#issuecomment-541873074.  Not tested at all.

The issue is that the client must always respond with a teleport confirm, even if it doesn't care about motion otherwise.  However, to get the teleport ID to confirm, all of the data before it needs to have been processed, or else it'll be reading the first field (the x position in this case, which is not a VarInt but still might happen to parse correctly as one) instead of the teleport ID.  The crash would happen if the x position has the first bit set in 5 bytes, which is uncommon (for one, it requires a negative coordinate, but then a bits need to be set too).  One such coordinate should be `-8577.5059` (`0xC0C0C0C0C154C986`), but again, I have not done any testing.