### PR TITLE
Fix Console Client crashes when using the /inventory click command

### DIFF
--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -542,6 +542,7 @@ namespace MinecraftClient.Protocol.Handlers
                                 if (item != null)
                                     inventorySlots[slotId] = item;
                             }
+                            window_actions[windowId] = 0;
                             handler.OnWindowItems(windowId, inventorySlots);
                         }
                         break;


### PR DESCRIPTION
issues #912
related:
#911 
#903 

Little explanation:
Player inventory is sent in `WindowItems` packet but didn't add the `window_actions[windowID] = 0;` when handling that packet.