### PR TITLE
Strip Minecraft Color Codes (§) in BasicIO mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /Other/
 /.vs/
 SessionCache.ini
+.*

--- a/MinecraftClient/ChatBot.cs
+++ b/MinecraftClient/ChatBot.cs
@@ -240,7 +240,7 @@ namespace MinecraftClient
         /// <summary>
         /// Remove color codes ("§c") from a text message received from the server
         /// </summary>
-        protected static string GetVerbatim(string text)
+        public static string GetVerbatim(string text)
         {
             if ( String.IsNullOrEmpty(text) )
                 return String.Empty;

--- a/MinecraftClient/ConsoleIO.cs
+++ b/MinecraftClient/ConsoleIO.cs
@@ -345,11 +345,7 @@ namespace MinecraftClient
                 {
                     if (BasicIO_NoColor)
                     {
-                        string colorcodes = "0123456789abcdefklmnor";
-                        foreach (char c in colorcodes)
-                        {
-                          str = str.Replace("§"+c, string.Empty);
-                        }
+                        str = ChatBot.GetVerbatim(str);
                     }
                     Console.WriteLine(str);
                     return;

--- a/MinecraftClient/ConsoleIO.cs
+++ b/MinecraftClient/ConsoleIO.cs
@@ -56,6 +56,13 @@ namespace MinecraftClient
         public static bool BasicIO = false;
 
         /// <summary>
+        /// Determines whether to use interactive IO or basic IO.
+        /// Set to true to disable interactive command prompt and use the default Console.Read|Write() methods.
+        /// Color codes are NOT printed when BasicIO_NoColor is enabled.
+        /// </summary>
+        public static bool BasicIO_NoColor = false;
+
+        /// <summary>
         /// Determine whether WriteLineFormatted() should prepend lines with timestamps by default.
         /// </summary>
         public static bool EnableTimestamps = false;
@@ -336,7 +343,7 @@ namespace MinecraftClient
                 }
                 if (BasicIO)
                 {
-                    if (Settings.ConsoleIOColor_Enabled == false)
+                    if (BasicIO_NoColor)
                     {
                         string colorcodes = "0123456789abcdefklmnor";
                         foreach (char c in colorcodes)

--- a/MinecraftClient/ConsoleIO.cs
+++ b/MinecraftClient/ConsoleIO.cs
@@ -56,9 +56,7 @@ namespace MinecraftClient
         public static bool BasicIO = false;
 
         /// <summary>
-        /// Determines whether to use interactive IO or basic IO.
-        /// Set to true to disable interactive command prompt and use the default Console.Read|Write() methods.
-        /// Color codes are NOT printed when BasicIO_NoColor is enabled.
+        /// Determines whether not to print color codes in BasicIO mode.
         /// </summary>
         public static bool BasicIO_NoColor = false;
 

--- a/MinecraftClient/ConsoleIO.cs
+++ b/MinecraftClient/ConsoleIO.cs
@@ -336,6 +336,14 @@ namespace MinecraftClient
                 }
                 if (BasicIO)
                 {
+                    if (Settings.ConsoleIOColor_Enabled == false)
+                    {
+                        string colorcodes = "0123456789abcdefklmnor";
+                        foreach (char c in colorcodes)
+                        {
+                          str = str.Replace("§"+c, string.Empty);
+                        }
+                    }
                     Console.WriteLine(str);
                     return;
                 }

--- a/MinecraftClient/Program.cs
+++ b/MinecraftClient/Program.cs
@@ -61,12 +61,13 @@ namespace MinecraftClient
             ConsoleIO.LogPrefix = "§8[MCC] ";
             if (args.Length >= 1 && args[args.Length - 1] == "BasicIO" || args.Length >= 1 && args[args.Length - 1] == "BasicIO-NoColors")
             {
+                if (args.Length >= 1 && args[args.Length - 1] == "BasicIO-NoColors")
+                {
+                    ConsoleIO.BasicIO_NoColor = true;
+                }
                 ConsoleIO.BasicIO = true;
                 args = args.Where(o => !Object.ReferenceEquals(o, args[args.Length - 1])).ToArray();
             }
-            if (args.Length >= 1 && args[args.Length - 1] == "BasicIO-NoColors")
-            {
-                ConsoleIO.BasicIO_NoColor = true;
 
             //Take advantage of Windows 10 / Mac / Linux UTF-8 console
             if (isUsingMono || WindowsVersion.WinMajorVersion >= 10)

--- a/MinecraftClient/Program.cs
+++ b/MinecraftClient/Program.cs
@@ -59,9 +59,9 @@ namespace MinecraftClient
 
             //Setup ConsoleIO
             ConsoleIO.LogPrefix = "§8[MCC] ";
-            if (args.Length >= 1 && args[args.Length - 1] == "BasicIO" || args.Length >= 1 && args[args.Length - 1] == "BasicIO-NoColors")
+            if (args.Length >= 1 && args[args.Length - 1] == "BasicIO" || args.Length >= 1 && args[args.Length - 1] == "BasicIO-NoColor")
             {
-                if (args.Length >= 1 && args[args.Length - 1] == "BasicIO-NoColors")
+                if (args.Length >= 1 && args[args.Length - 1] == "BasicIO-NoColor")
                 {
                     ConsoleIO.BasicIO_NoColor = true;
                 }

--- a/MinecraftClient/Program.cs
+++ b/MinecraftClient/Program.cs
@@ -59,11 +59,14 @@ namespace MinecraftClient
 
             //Setup ConsoleIO
             ConsoleIO.LogPrefix = "§8[MCC] ";
-            if (args.Length >= 1 && args[args.Length - 1] == "BasicIO")
+            if (args.Length >= 1 && args[args.Length - 1] == "BasicIO" || args.Length >= 1 && args[args.Length - 1] == "BasicIO-NoColors")
             {
                 ConsoleIO.BasicIO = true;
                 args = args.Where(o => !Object.ReferenceEquals(o, args[args.Length - 1])).ToArray();
             }
+            if (args.Length >= 1 && args[args.Length - 1] == "BasicIO-NoColors")
+            {
+                ConsoleIO.BasicIO_NoColor = true;
 
             //Take advantage of Windows 10 / Mac / Linux UTF-8 console
             if (isUsingMono || WindowsVersion.WinMajorVersion >= 10)

--- a/MinecraftClient/Settings.cs
+++ b/MinecraftClient/Settings.cs
@@ -97,6 +97,7 @@ namespace MinecraftClient
         public static bool ResolveSrvRecordsShortTimeout = true;
         public static bool EntityHandling = false;
         public static bool AutoRespawn = false;
+        public static bool ConsoleIOColor_Enabled = true;
 
         //AntiAFK Settings
         public static bool AntiAFK_Enabled = false;
@@ -249,6 +250,7 @@ namespace MinecraftClient
                                                 case "botmessagedelay": botMessageDelay = TimeSpan.FromSeconds(str2int(argValue)); break;
                                                 case "debugmessages": DebugMessages = str2bool(argValue); break;
                                                 case "autorespawn": AutoRespawn = str2bool(argValue); break;
+                                                case "consoleiocolors": ConsoleIOColor_Enabled = str2bool(argValue); break;
 
                                                 case "botowners":
                                                     Bots_Owners.Clear();
@@ -601,6 +603,7 @@ namespace MinecraftClient
                 + "scriptcache=true                   # Cache compiled scripts for faster load on low-end devices\r\n"
                 + "timestamps=false                   # Prepend timestamps to chat messages\r\n"
                 + "autorespawn=false                  # Toggle auto respawn if client player was dead (make sure your spawn point is safe)\r\n"
+                + "consoleiocolors=true               # Strips the color codes from output when in BasicIO mode\r\n"
                 + "\r\n"
                 + "[AppVars]\r\n"
                 + "# yourvar=yourvalue\r\n"

--- a/MinecraftClient/Settings.cs
+++ b/MinecraftClient/Settings.cs
@@ -97,7 +97,6 @@ namespace MinecraftClient
         public static bool ResolveSrvRecordsShortTimeout = true;
         public static bool EntityHandling = false;
         public static bool AutoRespawn = false;
-        public static bool ConsoleIOColor_Enabled = true;
 
         //AntiAFK Settings
         public static bool AntiAFK_Enabled = false;
@@ -250,7 +249,6 @@ namespace MinecraftClient
                                                 case "botmessagedelay": botMessageDelay = TimeSpan.FromSeconds(str2int(argValue)); break;
                                                 case "debugmessages": DebugMessages = str2bool(argValue); break;
                                                 case "autorespawn": AutoRespawn = str2bool(argValue); break;
-                                                case "consoleiocolors": ConsoleIOColor_Enabled = str2bool(argValue); break;
 
                                                 case "botowners":
                                                     Bots_Owners.Clear();
@@ -603,7 +601,6 @@ namespace MinecraftClient
                 + "scriptcache=true                   # Cache compiled scripts for faster load on low-end devices\r\n"
                 + "timestamps=false                   # Prepend timestamps to chat messages\r\n"
                 + "autorespawn=false                  # Toggle auto respawn if client player was dead (make sure your spawn point is safe)\r\n"
-                + "consoleiocolors=true               # Strips the color codes from output when in BasicIO mode\r\n"
                 + "\r\n"
                 + "[AppVars]\r\n"
                 + "# yourvar=yourvalue\r\n"


### PR DESCRIPTION
Adds a configuration setting in MinecraftClient.ini to strip all color codes and formatting from output when in BasicIO mode. Makes chat logs much more readable.

I use Docker to run Mono, so I need to use BasicIO mode to be able to run, stripping color and formatting codes makes it easier to interact with players.

![Screenshot_2020-05-12 Portainer](https://user-images.githubusercontent.com/31938727/81747289-d8f15300-9475-11ea-9416-b04c4caeb6cd.png)
![Screenshot_2020-05-12 Portainer(1)](https://user-images.githubusercontent.com/31938727/81747318-e3135180-9475-11ea-923b-41c85c6f8765.png)
