### PR TITLE
More transparent notifications about unsupported features

### DIFF
--- a/MinecraftClient/Protocol/Handlers/Protocol16.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol16.cs
@@ -38,19 +38,19 @@ namespace MinecraftClient.Protocol.Handlers
 
             if (Handler.GetTerrainEnabled())
             {
-                ConsoleIO.WriteLineFormatted("§8Terrain & Movements currently not handled for that MC version.");
+                ConsoleIO.WriteLineFormatted("§cTerrain & Movements currently not handled for that MC version.");
                 Handler.SetTerrainEnabled(false);
             }
 
             if (handler.GetInventoryEnabled())
             {
-                ConsoleIO.WriteLineFormatted("§8Inventories are currently not handled for that MC version.");
+                ConsoleIO.WriteLineFormatted("§cInventories are currently not handled for that MC version.");
                 handler.SetInventoryEnabled(false);
             }
 
             if (handler.GetEntityHandlingEnabled())
             {
-                ConsoleIO.WriteLineFormatted("§8Entities are currently not handled for that MC version.");
+                ConsoleIO.WriteLineFormatted("§cEntities are currently not handled for that MC version.");
                 handler.SetEntityHandlingEnabled(false);
             }
         }

--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -81,19 +81,19 @@ namespace MinecraftClient.Protocol.Handlers
 
             if (handler.GetTerrainEnabled() && protocolversion > MC1152Version)
             {
-                ConsoleIO.WriteLineFormatted("§8Terrain & Movements currently not handled for that MC version.");
+                ConsoleIO.WriteLineFormatted("§cTerrain & Movements currently not handled for that MC version.");
                 handler.SetTerrainEnabled(false);
             }
 
             if (handler.GetInventoryEnabled() && (protocolversion < MC110Version || protocolversion > MC1163Version))
             {
-                ConsoleIO.WriteLineFormatted("§8Inventories are currently not handled for that MC version.");
+                ConsoleIO.WriteLineFormatted("§cInventories are currently not handled for that MC version.");
                 handler.SetInventoryEnabled(false);
             }
 
             if (handler.GetEntityHandlingEnabled() && (protocolversion < MC110Version || protocolversion > MC1163Version))
             {
-                ConsoleIO.WriteLineFormatted("§8Entities are currently not handled for that MC version.");
+                ConsoleIO.WriteLineFormatted("§cEntities are currently not handled for that MC version.");
                 handler.SetEntityHandlingEnabled(false);
             }
 


### PR DESCRIPTION
Changed the "Terrain & Movements/Inventories/Entities are currently not handled for that MC version" message display upon startup from dark gray to red to more obviously point out the issue.

![image](https://user-images.githubusercontent.com/13611718/93889545-9aa05600-fce9-11ea-8d0f-afca59832207.png)
