### PR TITLE
Update to MC version 1.16.5

### DIFF
--- a/MinecraftClient/Program.cs
+++ b/MinecraftClient/Program.cs
@@ -32,7 +32,7 @@ namespace MinecraftClient
 
         public const string Version = MCHighestVersion;
         public const string MCLowestVersion = "1.4.6";
-        public const string MCHighestVersion = "1.16.4";
+        public const string MCHighestVersion = "1.16.5";
         public static readonly string BuildInfo = null;
 
         private static Thread offlinePrompt = null;

--- a/MinecraftClient/Protocol/Handlers/PacketType18Handler.cs
+++ b/MinecraftClient/Protocol/Handlers/PacketType18Handler.cs
@@ -39,7 +39,7 @@ namespace MinecraftClient.Protocol.Handlers
         /// <returns></returns>
         public PacketTypePalette GetTypeHandler(int protocol)
         {
-            if (protocol > Protocol18Handler.MC1164Version)
+            if (protocol > Protocol18Handler.MC1165Version)
                 throw new NotImplementedException(Translations.Get("exception.palette.packet"));
             if (protocol <= Protocol18Handler.MC18Version)
                 return new PacketPalette17();

--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -47,7 +47,7 @@ namespace MinecraftClient.Protocol.Handlers
         internal const int MC1161Version = 736;
         internal const int MC1162Version = 751;
         internal const int MC1163Version = 753;
-        internal const int MC1165Version = 754; // Renamed from 1.16.4 to 1.16.5 as they have same no.
+        internal const int MC1165Version = 754;
 
         private int compression_treshold = 0;
         private bool autocomplete_received = false;

--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -47,7 +47,7 @@ namespace MinecraftClient.Protocol.Handlers
         internal const int MC1161Version = 736;
         internal const int MC1162Version = 751;
         internal const int MC1163Version = 753;
-        internal const int MC1164Version = 754;
+        internal const int MC1165Version = 754; // Renamed from 1.16.4 to 1.16.5 as they have same no.
 
         private int compression_treshold = 0;
         private bool autocomplete_received = false;
@@ -80,19 +80,19 @@ namespace MinecraftClient.Protocol.Handlers
             this.pTerrain = new Protocol18Terrain(protocolVersion, dataTypes, handler);
             this.packetPalette = new PacketTypeHandler(protocolVersion).GetTypeHandler();
 
-            if (handler.GetTerrainEnabled() && protocolversion > MC1164Version)
+            if (handler.GetTerrainEnabled() && protocolversion > MC1165Version)
             {
                 Translations.WriteLineFormatted("extra.terrainandmovement_disabled");
                 handler.SetTerrainEnabled(false);
             }
 
-            if (handler.GetInventoryEnabled() && (protocolversion < MC110Version || protocolversion > MC1164Version))
+            if (handler.GetInventoryEnabled() && (protocolversion < MC110Version || protocolversion > MC1165Version))
             {
                 Translations.WriteLineFormatted("extra.inventory_disabled");
                 handler.SetInventoryEnabled(false);
             }
 
-            if (handler.GetEntityHandlingEnabled() && (protocolversion < MC110Version || protocolversion > MC1164Version))
+            if (handler.GetEntityHandlingEnabled() && (protocolversion < MC110Version || protocolversion > MC1165Version))
             {
                 Translations.WriteLineFormatted("extra.entity_disabled");
                 handler.SetEntityHandlingEnabled(false);
@@ -101,7 +101,7 @@ namespace MinecraftClient.Protocol.Handlers
             // Block palette
             if (protocolversion >= MC113Version)
             {
-                if (protocolVersion > MC1164Version && handler.GetTerrainEnabled())
+                if (protocolVersion > MC1165Version && handler.GetTerrainEnabled())
                     throw new NotImplementedException(Translations.Get("exception.palette.block"));
                 if (protocolVersion >= MC116Version)
                     Block.Palette = new Palette116();
@@ -116,7 +116,7 @@ namespace MinecraftClient.Protocol.Handlers
             // Entity palette
             if (protocolversion >= MC113Version)
             {
-                if (protocolversion > MC1164Version && handler.GetEntityHandlingEnabled())
+                if (protocolversion > MC1165Version && handler.GetEntityHandlingEnabled())
                     throw new NotImplementedException(Translations.Get("exception.palette.entity"));
                 if (protocolversion >= MC1162Version)
                     entityPalette = new EntityPalette1162();
@@ -133,7 +133,7 @@ namespace MinecraftClient.Protocol.Handlers
             // Item palette
             if (protocolversion >= MC116Version)
             {
-                if (protocolversion > MC1164Version && handler.GetInventoryEnabled())
+                if (protocolversion > MC1165Version && handler.GetInventoryEnabled())
                     throw new NotImplementedException(Translations.Get("exception.palette.item"));
                 if (protocolversion >= MC1162Version)
                     itemPalette = new ItemPalette1162();

--- a/MinecraftClient/Protocol/ProtocolHandler.cs
+++ b/MinecraftClient/Protocol/ProtocolHandler.cs
@@ -305,7 +305,7 @@ namespace MinecraftClient.Protocol
                 case 736: return "1.16.1";
                 case 751: return "1.16.2";
                 case 753: return "1.16.3";
-                case 754: return "1.16.5"; // 754 => 1.16.4/1.16.5 (they share the same no.)
+                case 754: return "1.16.5";
                 default: return "0.0";
             }
         }

--- a/MinecraftClient/Protocol/ProtocolHandler.cs
+++ b/MinecraftClient/Protocol/ProtocolHandler.cs
@@ -243,6 +243,7 @@ namespace MinecraftClient.Protocol
                     case "1.16.3":
                         return 753;
                     case "1.16.4":
+                    case "1.16.5":
                         return 754;
                     default:
                         return 0;
@@ -303,6 +304,8 @@ namespace MinecraftClient.Protocol
                 case 735: return "1.16";
                 case 736: return "1.16.1";
                 case 751: return "1.16.2";
+                case 753: return "1.16.3";
+                case 754: return "1.16.5"; // 754 => 1.16.4/1.16.5 (they share the same no.)
                 default: return "0.0";
             }
         }


### PR DESCRIPTION
_Note: According to [Minecraft wiki](https://minecraft.gamepedia.com/Java_Edition_1.16.5), `1.16.4` and `1.16.5` share the same protocol number `754`._