### PR TITLE
Fix unknown packet ID cause crash

### DIFF
--- a/MinecraftClient/Protocol/Handlers/PacketPalettes/PacketTypePalette.cs
+++ b/MinecraftClient/Protocol/Handlers/PacketPalettes/PacketTypePalette.cs
@@ -57,7 +57,12 @@ namespace MinecraftClient.Protocol.Handlers.PacketPalettes
         /// <returns>Packet type</returns>
         public PacketTypesIn GetIncommingTypeById(int packetId)
         {
-            return GetListIn()[packetId];
+            PacketTypesIn p;
+            if (GetListIn().TryGetValue(packetId, out p))
+            {
+                return p;
+            }
+            else return PacketTypesIn.Unknown;
         }
 
         /// <summary>
@@ -77,7 +82,12 @@ namespace MinecraftClient.Protocol.Handlers.PacketPalettes
         /// <returns>Packet type</returns>
         public PacketTypesOut GetOutgoingTypeById(int packetId)
         {
-            return GetListOut()[packetId];
+            PacketTypesOut p;
+            if (GetListOut().TryGetValue(packetId, out p))
+            {
+                return p;
+            }
+            else return PacketTypesOut.Unknown;
         }
 
         /// <summary>

--- a/MinecraftClient/Protocol/Handlers/PacketPalettes/PacketTypePalette.cs
+++ b/MinecraftClient/Protocol/Handlers/PacketPalettes/PacketTypePalette.cs
@@ -38,6 +38,8 @@ namespace MinecraftClient.Protocol.Handlers.PacketPalettes
 
         private Dictionary<PacketTypesOut, int> reverseMappingOut = new Dictionary<PacketTypesOut, int>();
 
+        private bool forgeEnabled = false;
+
         public PacketTypePalette()
         {
             foreach (var p in GetListIn())
@@ -62,7 +64,14 @@ namespace MinecraftClient.Protocol.Handlers.PacketPalettes
             {
                 return p;
             }
-            else return PacketTypesIn.Unknown;
+            else if (forgeEnabled)
+            {
+                if (Settings.DebugMessages)
+                    ConsoleIO.WriteLogLine("Ignoring unknown packet ID of 0x" + packetId.ToString("X2"));
+                return PacketTypesIn.Unknown;
+            }
+            else
+                throw new KeyNotFoundException("Packet ID of 0x" + packetId.ToString("X2") + " doesn't exist!");
         }
 
         /// <summary>
@@ -87,7 +96,14 @@ namespace MinecraftClient.Protocol.Handlers.PacketPalettes
             {
                 return p;
             }
-            else return PacketTypesOut.Unknown;
+            else if (forgeEnabled)
+            {
+                if (Settings.DebugMessages)
+                    ConsoleIO.WriteLogLine("Ignoring unknown packet ID of 0x" + packetId.ToString("X2"));
+                return PacketTypesOut.Unknown;
+            }
+            else
+                throw new KeyNotFoundException("Packet ID of 0x" + packetId.ToString("X2") + " doesn't exist!");
         }
 
         /// <summary>
@@ -117,6 +133,20 @@ namespace MinecraftClient.Protocol.Handlers.PacketPalettes
         public Dictionary<int ,PacketTypesOut> GetMappingOut()
         {
             return GetListOut();
+        }
+
+        /// <summary>
+        /// Enable forge or disable forge
+        /// </summary>
+        /// <remarks>
+        /// Have a rare chance that forge mod may modify packet ID.
+        /// Ignore packet type not found when forge enabled to
+        /// prevent program crash.
+        /// </remarks>
+        /// <param name="enabled"></param>
+        public void SetForgeEnabled(bool enabled)
+        {
+            this.forgeEnabled = enabled;
         }
     }
 }

--- a/MinecraftClient/Protocol/Handlers/PacketType18Handler.cs
+++ b/MinecraftClient/Protocol/Handlers/PacketType18Handler.cs
@@ -10,6 +10,7 @@ namespace MinecraftClient.Protocol.Handlers
     public class PacketTypeHandler
     {
         private int protocol;
+        private bool forgeEnabled = false;
 
         /// <summary>
         /// Initialize the handler
@@ -18,6 +19,16 @@ namespace MinecraftClient.Protocol.Handlers
         public PacketTypeHandler(int protocol)
         {
             this.protocol = protocol;
+        }
+        /// <summary>
+        /// Initialize the handler
+        /// </summary>
+        /// <param name="protocol">Protocol version to use</param>
+        /// <param name="forgeEnabled">Is forge enabled or not</param>
+        public PacketTypeHandler(int protocol, bool forgeEnabled)
+        {
+            this.protocol = protocol;
+            this.forgeEnabled = forgeEnabled;
         }
         /// <summary>
         /// Initialize the handler
@@ -39,25 +50,29 @@ namespace MinecraftClient.Protocol.Handlers
         /// <returns></returns>
         public PacketTypePalette GetTypeHandler(int protocol)
         {
+            PacketTypePalette p;
             if (protocol > Protocol18Handler.MC1165Version)
                 throw new NotImplementedException(Translations.Get("exception.palette.packet"));
             if (protocol <= Protocol18Handler.MC18Version)
-                return new PacketPalette17();
+                p = new PacketPalette17();
             else if (protocol <= Protocol18Handler.MC1112Version)
-                return new PacketPalette110();
+                p = new PacketPalette110();
             else if (protocol <= Protocol18Handler.MC112Version)
-                return new PacketPalette112();
+                p = new PacketPalette112();
             else if (protocol <= Protocol18Handler.MC1122Version)
-                return new PacketPalette1122();
+                p = new PacketPalette1122();
             else if (protocol <= Protocol18Handler.MC114Version)
-                return new PacketPalette113();
+                p = new PacketPalette113();
             else if (protocol <= Protocol18Handler.MC115Version)
-                return new PacketPalette114();
+                p = new PacketPalette114();
             else if (protocol <= Protocol18Handler.MC1152Version)
-                return new PacketPalette115();
+                p = new PacketPalette115();
             else if (protocol <= Protocol18Handler.MC1161Version)
-                return new PacketPalette116();
-            else return new PacketPalette1162();
+                p = new PacketPalette116();
+            else p = new PacketPalette1162();
+
+            p.SetForgeEnabled(this.forgeEnabled);
+            return p;
         }
     }
 }

--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -78,7 +78,7 @@ namespace MinecraftClient.Protocol.Handlers
             this.handler = handler;
             this.pForge = new Protocol18Forge(forgeInfo, protocolVersion, dataTypes, this, handler);
             this.pTerrain = new Protocol18Terrain(protocolVersion, dataTypes, handler);
-            this.packetPalette = new PacketTypeHandler(protocolVersion).GetTypeHandler();
+            this.packetPalette = new PacketTypeHandler(protocolVersion, forgeInfo != null).GetTypeHandler();
 
             if (handler.GetTerrainEnabled() && protocolversion > MC1165Version)
             {


### PR DESCRIPTION
Fix #1419

_I am doubt about ignoring unknown packet ID is a good idea... since a bad/incorrect packet palette might also cause `IndexOutOfBound`_