### PR TITLE
Implement browser sign-in method

### DIFF
--- a/MinecraftClient/Program.cs
+++ b/MinecraftClient/Program.cs
@@ -136,24 +136,21 @@ namespace MinecraftClient
             }
 
             //Asking the user to type in missing data such as Username and Password
-
-            if (Settings.AccountType == ProtocolHandler.AccountType.Microsoft
-                && Settings.LoginMethod == "browser")
+            bool useBrowser = Settings.AccountType == ProtocolHandler.AccountType.Microsoft && Settings.LoginMethod == "browser";
+            if (Settings.Login == "")
             {
-                // Login with browser. Skip ask email and password
+                if (useBrowser)
+                    ConsoleIO.WriteLine("Press Enter to skip session cache checking and continue sign-in with browser");
+                Console.Write(ConsoleIO.BasicIO ? Translations.Get("mcc.login_basic_io") + "\n" : Translations.Get("mcc.login"));
+                Settings.Login = Console.ReadLine();
             }
-            else
+            if (Settings.Password == "" 
+                && (Settings.SessionCaching == CacheType.None || !SessionCache.Contains(Settings.Login.ToLower()))
+                && !useBrowser)
             {
-                if (Settings.Login == "")
-                {
-                    Console.Write(ConsoleIO.BasicIO ? Translations.Get("mcc.login_basic_io") + "\n" : Translations.Get("mcc.login"));
-                    Settings.Login = Console.ReadLine();
-                }
-                if (Settings.Password == "" && (Settings.SessionCaching == CacheType.None || !SessionCache.Contains(Settings.Login.ToLower())))
-                {
-                    RequestPassword();
-                }
+                RequestPassword();
             }
+            
 
             startupargs = args;
             InitializeClient();

--- a/MinecraftClient/Program.cs
+++ b/MinecraftClient/Program.cs
@@ -137,14 +137,22 @@ namespace MinecraftClient
 
             //Asking the user to type in missing data such as Username and Password
 
-            if (Settings.Login == "")
+            if (Settings.AccountType == ProtocolHandler.AccountType.Microsoft
+                && Settings.LoginMethod == "browser")
             {
-                Console.Write(ConsoleIO.BasicIO ? Translations.Get("mcc.login_basic_io") + "\n" : Translations.Get("mcc.login"));
-                Settings.Login = Console.ReadLine();
+                // Login with browser. Skip ask email and password
             }
-            if (Settings.Password == "" && (Settings.SessionCaching == CacheType.None || !SessionCache.Contains(Settings.Login.ToLower())))
+            else
             {
-                RequestPassword();
+                if (Settings.Login == "")
+                {
+                    Console.Write(ConsoleIO.BasicIO ? Translations.Get("mcc.login_basic_io") + "\n" : Translations.Get("mcc.login"));
+                    Settings.Login = Console.ReadLine();
+                }
+                if (Settings.Password == "" && (Settings.SessionCaching == CacheType.None || !SessionCache.Contains(Settings.Login.ToLower())))
+                {
+                    RequestPassword();
+                }
             }
 
             startupargs = args;
@@ -209,7 +217,6 @@ namespace MinecraftClient
                         SessionCache.Store(Settings.Login.ToLower(), session);
                     }
                 }
-
             }
 
             if (result == ProtocolHandler.LoginResult.Success)

--- a/MinecraftClient/Program.cs
+++ b/MinecraftClient/Program.cs
@@ -319,6 +319,7 @@ namespace MinecraftClient
                     case ProtocolHandler.LoginResult.NotPremium: failureReason = "error.login.premium"; break;
                     case ProtocolHandler.LoginResult.OtherError: failureReason = "error.login.network"; break;
                     case ProtocolHandler.LoginResult.SSLError: failureReason = "error.login.ssl"; break;
+                    case ProtocolHandler.LoginResult.UserCancel: failureReason = "error.login.cancel"; break;
                     default: failureReason = "error.login.unknown"; break;
                 }
                 failureMessage += Translations.Get(failureReason);

--- a/MinecraftClient/Protocol/MicrosoftAuthentication.cs
+++ b/MinecraftClient/Protocol/MicrosoftAuthentication.cs
@@ -21,6 +21,8 @@ namespace MinecraftClient.Protocol
         private Regex invalidAccount = new Regex("Sign in to", RegexOptions.IgnoreCase);
         private Regex twoFA = new Regex("Help us protect your account", RegexOptions.IgnoreCase);
 
+        public string SignInUrl { get { return authorize; } }
+
         /// <summary>
         /// Pre-authentication
         /// </summary>
@@ -114,7 +116,7 @@ namespace MinecraftClient.Protocol
                 if (twoFA.IsMatch(response.Body))
                 {
                     // TODO: Handle 2FA
-                    throw new Exception("2FA enabled but not supported yet. Try to disable it in Microsoft account settings");
+                    throw new Exception("2FA enabled but not supported yet. Use browser sign-in method or try to disable 2FA in Microsoft account settings");
                 }
                 else if (invalidAccount.IsMatch(response.Body))
                 {

--- a/MinecraftClient/Protocol/ProtocolHandler.cs
+++ b/MinecraftClient/Protocol/ProtocolHandler.cs
@@ -483,7 +483,7 @@ namespace MinecraftClient.Protocol
         public static LoginResult MicrosoftBrowserLogin(out SessionToken session)
         {
             var ms = new XboxLive();
-            string[] askOpenLike =
+            string[] askOpenLink =
             {
                 "Copy the following link to your browser and login to your Microsoft Account",
                 ">>>>>>>>>>>>>>>>>>>>>>",
@@ -491,13 +491,21 @@ namespace MinecraftClient.Protocol
                 ms.SignInUrl,
                 "",
                 "<<<<<<<<<<<<<<<<<<<<<<",
-                "When you see a blank page after signing in, copy the link from browser and paste it below"
+                "NOTICE: Once successfully logged in, you will see a blank page in your web browser.",
+                "Copy the contents of your browser's address bar and paste it below to complete the login process.",
             };
-            ConsoleIO.WriteLine(string.Join("\n", askOpenLike));
+            ConsoleIO.WriteLine(string.Join("\n", askOpenLink));
             string[] parts = { };
             while (true)
             {
                 string link = ConsoleIO.ReadLine();
+                if (string.IsNullOrEmpty(link))
+                {
+                    ConsoleIO.WriteLine("Login cancelled.");
+                    Program.Exit();
+                    session = new SessionToken();
+                    return LoginResult.OtherError;
+                }
                 parts = link.Split('#');
                 if (parts.Length < 2)
                 {

--- a/MinecraftClient/Protocol/ProtocolHandler.cs
+++ b/MinecraftClient/Protocol/ProtocolHandler.cs
@@ -494,8 +494,19 @@ namespace MinecraftClient.Protocol
                 "When you see a blank page after signing in, copy the link from browser and paste it below"
             };
             ConsoleIO.WriteLine(string.Join("\n", askOpenLike));
-            string link = ConsoleIO.ReadLine();
-            string hash = link.Split('#')[1];
+            string[] parts = { };
+            while (true)
+            {
+                string link = ConsoleIO.ReadLine();
+                parts = link.Split('#');
+                if (parts.Length < 2)
+                {
+                    ConsoleIO.WriteLine("Invalid link. Please try again.");
+                    continue;
+                }
+                else break;
+            }
+            string hash = parts[1];
             var dict = Request.ParseQueryString(hash);
             var msaResponse = new XboxLive.UserLoginResponse()
             {

--- a/MinecraftClient/Protocol/ProtocolHandler.cs
+++ b/MinecraftClient/Protocol/ProtocolHandler.cs
@@ -330,7 +330,7 @@ namespace MinecraftClient.Protocol
             return Protocol18Forge.ServerForceForge(protocol);
         }
 
-        public enum LoginResult { OtherError, ServiceUnavailable, SSLError, Success, WrongPassword, AccountMigrated, NotPremium, LoginRequired, InvalidToken, InvalidResponse, NullError };
+        public enum LoginResult { OtherError, ServiceUnavailable, SSLError, Success, WrongPassword, AccountMigrated, NotPremium, LoginRequired, InvalidToken, InvalidResponse, NullError, UserCancel };
         public enum AccountType { Mojang, Microsoft };
 
         /// <summary>
@@ -501,10 +501,8 @@ namespace MinecraftClient.Protocol
                 string link = ConsoleIO.ReadLine();
                 if (string.IsNullOrEmpty(link))
                 {
-                    ConsoleIO.WriteLine("Login cancelled.");
-                    Program.Exit();
                     session = new SessionToken();
-                    return LoginResult.OtherError;
+                    return LoginResult.UserCancel;
                 }
                 parts = link.Split('#');
                 if (parts.Length < 2)

--- a/MinecraftClient/Resources/config/MinecraftClient.ini
+++ b/MinecraftClient/Resources/config/MinecraftClient.ini
@@ -10,6 +10,7 @@ login=
 password=
 serverip=
 type=mojang                        # Account type. mojang or microsoft
+method=mcc                         # Microsoft Account sign-in method. mcc OR browser
 
 # Advanced settings
 

--- a/MinecraftClient/Resources/lang/en.ini
+++ b/MinecraftClient/Resources/lang/en.ini
@@ -66,6 +66,7 @@ error.login.network=Network error.
 error.login.ssl=SSL Error.
 error.login.unknown=Unknown Error.
 error.login.ssl_help=§8It appears that you are using Mono to run this program.\nThe first time, you have to import HTTPS certificates using:\nmozroots --import --ask-remove
+error.login.cancel=User cancelled.
 error.login_failed=Failed to login to this server.
 error.join=Failed to join this server.
 error.connect=Failed to connect to this IP.

--- a/MinecraftClient/Settings.cs
+++ b/MinecraftClient/Settings.cs
@@ -26,6 +26,7 @@ namespace MinecraftClient
         public static string Username = "";
         public static string Password = "";
         public static ProtocolHandler.AccountType AccountType = ProtocolHandler.AccountType.Mojang;
+        public static string LoginMethod = "mcc";
         public static string ServerIP = "";
         public static ushort ServerPort = 25565;
         public static string ServerVersion = "";
@@ -277,6 +278,9 @@ namespace MinecraftClient
                                                 case "type": AccountType = argValue == "mojang" 
                                                         ? ProtocolHandler.AccountType.Mojang 
                                                         : ProtocolHandler.AccountType.Microsoft; break;
+                                                case "method": LoginMethod = argValue.ToLower() == "mcc"
+                                                        ? "mcc"
+                                                        : "browser"; break;
                                                 case "serverip": if (!SetServerIP(argValue)) serverAlias = argValue; ; break;
                                                 case "singlecommand": SingleCommand = argValue; break;
                                                 case "language": Language = argValue; break;

--- a/MinecraftClient/Settings.cs
+++ b/MinecraftClient/Settings.cs
@@ -278,9 +278,9 @@ namespace MinecraftClient
                                                 case "type": AccountType = argValue == "mojang" 
                                                         ? ProtocolHandler.AccountType.Mojang 
                                                         : ProtocolHandler.AccountType.Microsoft; break;
-                                                case "method": LoginMethod = argValue.ToLower() == "mcc"
-                                                        ? "mcc"
-                                                        : "browser"; break;
+                                                case "method": LoginMethod = argValue.ToLower() == "browser"
+                                                        ? "browser"
+                                                        : "mcc"; break;
                                                 case "serverip": if (!SetServerIP(argValue)) serverAlias = argValue; ; break;
                                                 case "singlecommand": SingleCommand = argValue; break;
                                                 case "language": Language = argValue; break;


### PR DESCRIPTION
Allow user to sign-in to their Microsoft Account by asking them to open sign-in page using browser. 

The downside is this require user to copy and paste lengthy content from and to console.
```
Sign-in page: 218 chars
Response URL: around 1500 chars
```

Also it is a bit lack of instruction because sign-in success will return a blank page. _Not a good method for people who don't read instructions._

---

At `ProtocolHandler.cs` L494:
`When you see a blank page after signing in, copy the link from browser and paste it below` 

My English is poor. I want user to copy and paste the URL back to MCC. @ORelio Could you please help me modify the sentence so that the instruction is more clear?
![image](https://user-images.githubusercontent.com/39955851/106572380-4f3d6480-6573-11eb-874d-8c56e3ba5b95.png)

