### PR TITLE
Adjust line break of default configuration file before writing

### DIFF
--- a/MinecraftClient/Settings.cs
+++ b/MinecraftClient/Settings.cs
@@ -718,8 +718,16 @@ namespace MinecraftClient
         /// <param name="settingsfile">File to (over)write</param>
         public static void WriteDefaultSettings(string settingsfile)
         {
-            // Use embedded default config
-            File.WriteAllText(settingsfile, "# Minecraft Console Client v" + Program.Version + "\r\n" + DefaultConfigResource.MinecraftClient, Encoding.UTF8);
+            // Load embedded default config and adjust line break for the current operating system
+            string settingsContents = String.Join(Environment.NewLine, 
+                DefaultConfigResource.MinecraftClient.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None));
+
+            // Write configuration file with current version number
+            File.WriteAllText(settingsfile,
+                "# Minecraft Console Client v"
+                + Program.Version
+                + Environment.NewLine
+                + settingsContents, Encoding.UTF8);
         }
 
         /// <summary>


### PR DESCRIPTION
The fix is working. I manually changed all line break from `\r\n` to `\n` in `Resources\config\MinecraftClient.ini` for testing. With the fix, it is able to change all line break from `\n` to `\r\n` on Windows. I didn't test it on Linux/Mac but they should work as well.

Fix #1536 