### PR TITLE
Add ability to perform clean-up code before quitting

### DIFF
--- a/MinecraftClient/ExitCleanUp.cs
+++ b/MinecraftClient/ExitCleanUp.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Runtime.InteropServices;
+
+namespace MinecraftClient
+{
+    /// <summary>
+    /// Perform clean up before quitting application
+    /// </summary>
+    /// <remarks>
+    /// Only ctrl+c/ctrl+break will be captured when running on mono
+    /// </remarks>
+    public static class ExitCleanUp
+    {
+        /// <summary>
+        /// Store codes to run before quitting
+        /// </summary>
+        private static List<Action> actions = new List<Action>();
+
+        static ExitCleanUp()
+        {
+            try
+            {
+                // Capture all close event
+                _handler += CleanUp;
+                // Use delegate directly cause program to crash
+                SetConsoleCtrlHandler(_handler, true);
+            }
+            catch (DllNotFoundException)
+            {
+                // Probably on mono, fallback to ctrl+c only
+                Console.CancelKeyPress += delegate (object sender, ConsoleCancelEventArgs e)
+                {
+                    RunCleanUp();
+                };
+            }
+        }
+
+        /// <summary>
+        /// Add a new action to be performed before application exit
+        /// </summary>
+        /// <param name="cleanUpCode">Action to run</param>
+        public static void Add(Action cleanUpCode)
+        {
+            actions.Add(cleanUpCode);
+        }
+
+        /// <summary>
+        /// Run all actions
+        /// </summary>
+        /// <remarks>
+        /// For .Net native
+        /// </remarks>
+        private static void RunCleanUp()
+        {
+            foreach (Action action in actions)
+            {
+                action();
+            }
+        }
+
+        /// <summary>
+        /// Run all actions
+        /// </summary>
+        /// <param name="sig"></param>
+        /// <returns></returns>
+        /// <remarks>
+        /// For win32 API
+        /// </remarks>
+        private static bool CleanUp(CtrlType sig)
+        {
+            foreach (Action action in actions)
+            {
+                action();
+            }
+            return false;
+        }
+
+        [DllImport("Kernel32")]
+        private static extern bool SetConsoleCtrlHandler(ConsoleCtrlHandler handler, bool add);
+        private delegate bool ConsoleCtrlHandler(CtrlType sig);
+        private static ConsoleCtrlHandler _handler;
+
+        enum CtrlType
+        {
+            CTRL_C_EVENT = 0,
+            CTRL_BREAK_EVENT = 1,
+            CTRL_CLOSE_EVENT = 2,
+            CTRL_LOGOFF_EVENT = 5,
+            CTRL_SHUTDOWN_EVENT = 6
+        }
+    }
+}

--- a/MinecraftClient/MinecraftClient.csproj
+++ b/MinecraftClient/MinecraftClient.csproj
@@ -119,7 +119,6 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>DefaultConfigResource.resx</DependentUpon>
     </Compile>
-    <Compile Include="ExitCleanUp.cs" />
     <Compile Include="Logger\FileLogLogger.cs" />
     <Compile Include="Logger\ILogger.cs" />
     <Compile Include="INIFile.cs" />
@@ -363,6 +362,7 @@
     <Compile Include="Settings.cs" />
     <Compile Include="Commands\List.cs" />
     <Compile Include="Mapping\Location.cs" />
+    <Compile Include="WinAPI\ExitCleanUp.cs" />
     <Compile Include="WinAPI\WindowsVersion.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/MinecraftClient/MinecraftClient.csproj
+++ b/MinecraftClient/MinecraftClient.csproj
@@ -119,6 +119,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>DefaultConfigResource.resx</DependentUpon>
     </Compile>
+    <Compile Include="ExitCleanUp.cs" />
     <Compile Include="Logger\FileLogLogger.cs" />
     <Compile Include="Logger\ILogger.cs" />
     <Compile Include="INIFile.cs" />

--- a/MinecraftClient/Program.cs
+++ b/MinecraftClient/Program.cs
@@ -150,6 +150,15 @@ namespace MinecraftClient
             {
                 RequestPassword();
             }
+
+            // Setup exit cleaning code
+            ExitCleanUp.Add(delegate () 
+            {
+                // Do NOT use Program.Exit() as creating new Thread cause program to freeze
+                if (client != null) { client.Disconnect(); ConsoleIO.Reset(); }
+                if (offlinePrompt != null) { offlinePrompt.Abort(); offlinePrompt = null; ConsoleIO.Reset(); }
+                if (Settings.playerHeadAsIcon) { ConsoleIcon.revertToMCCIcon(); }
+            });
             
 
             startupargs = args;

--- a/MinecraftClient/WinAPI/ExitCleanUp.cs
+++ b/MinecraftClient/WinAPI/ExitCleanUp.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Runtime.InteropServices;
 
-namespace MinecraftClient
+namespace MinecraftClient.WinAPI
 {
     /// <summary>
     /// Perform clean up before quitting application


### PR DESCRIPTION
Tested with `ReplayMod` feature, which require proper quitting, on both Windows and Mono platform.
![image](https://user-images.githubusercontent.com/39955851/116782331-f40c0700-aaba-11eb-83d4-b97e85988708.png)

_Replay file created can be played properly, i.e. not corrupted_

Resolve #1559