### PR TITLE
Remove thread sleep in disconnect method

### DIFF
--- a/MinecraftClient/McClient.cs
+++ b/MinecraftClient/McClient.cs
@@ -504,8 +504,6 @@ namespace MinecraftClient
                 timeoutdetector = null;
             }
 
-            Thread.Sleep(1000);
-
             if (client != null)
                 client.Close();
         }


### PR DESCRIPTION
_I don't see any reason why it is there :P_
_And It slows down the shutdown speed_