### PR TITLE
Add method to schedule main thread task

### DIFF
--- a/MinecraftClient/ChatBot.cs
+++ b/MinecraftClient/ChatBot.cs
@@ -61,7 +61,7 @@ namespace MinecraftClient
         /// <remarks>
         /// <see cref="Update"/> method can be overridden by child class so need an extra update method
         /// </remarks>
-        public void UpdateInternal()
+        public sealed void UpdateInternal()
         {
             lock (delayTasksLock)
             {

--- a/MinecraftClient/ChatBot.cs
+++ b/MinecraftClient/ChatBot.cs
@@ -41,6 +41,8 @@ namespace MinecraftClient
         private ChatBot master = null;
         private List<string> registeredPluginChannels = new List<String>();
         private List<string> registeredCommands = new List<string>();
+        private object delayTasksLock = new object();
+        private List<DelayedTask> delayTasks = new List<DelayedTask>();
         private McClient Handler
         {
             get
@@ -50,6 +52,39 @@ namespace MinecraftClient
                 if (_handler != null)
                     return _handler;
                 throw new InvalidOperationException(Translations.Get("exception.chatbot.init"));
+            }
+        }
+
+        /// <summary>
+        /// Will be called every ~100ms.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="Update"/> method can be overridden by child class so need an extra update method
+        /// </remarks>
+        public void UpdateInternal()
+        {
+            lock (delayTasksLock)
+            {
+                if (delayTasks.Count > 0)
+                {
+                    List<int> tasksToRemove = new List<int>();
+                    for (int i = 0; i < delayTasks.Count; i++)
+                    {
+                        if (delayTasks[i].Tick())
+                        {
+                            Handler.ScheduleTask(delayTasks[i].Task);
+                            tasksToRemove.Add(i);
+                        }
+                    }
+                    if (tasksToRemove.Count > 0)
+                    {
+                        tasksToRemove.Sort((a, b) => b.CompareTo(a)); // descending sort
+                        foreach (int index in tasksToRemove)
+                        {
+                            delayTasks.RemoveAt(index);
+                        }
+                    }
+                }
             }
         }
 
@@ -1355,6 +1390,38 @@ namespace MinecraftClient
         }
 
         /// <summary>
+        /// Schedule a task to run on main thread
+        /// </summary>
+        /// <param name="task">Task to run</param>
+        /// <param name="delayTicks">Run the task after X ticks (1 tick delay = ~100ms). 0 for no delay</param>
+        /// <example>
+        /// // Delay ~10 seconds
+        /// ScheduleTask(delegate () 
+        /// { 
+        ///     /** Your code here **/
+        ///     Console.WriteLine("10 seconds has passed");
+        /// }, 100);
+        /// </example>
+        protected void ScheduleTask(Action task, int delayTicks = 0)
+        {
+            if (task != null)
+            {
+                if (delayTicks <= 0)
+                {
+                    // Immediately schedule to run on next update
+                    Handler.ScheduleTask(task);
+                }
+                else
+                {
+                    lock (delayTasksLock)
+                    {
+                        delayTasks.Add(new DelayedTask(task, delayTicks));
+                    }
+                }
+            }
+        }
+
+        /// <summary>
         /// Command runner definition.
         /// Returned string will be the output of the command
         /// </summary>
@@ -1396,6 +1463,47 @@ namespace MinecraftClient
                 this._cmdDesc = cmdDesc;
                 this._cmdUsage = cmdUsage;
                 this.Runner = callback;
+            }
+        }
+
+        private class DelayedTask
+        {
+            private Action task;
+            private int Counter;
+
+            public Action Task { get { return task; } }
+
+            public DelayedTask(Action task)
+                : this(task, 0)
+            { }
+
+            public DelayedTask(Action task, int delayTicks)
+            {
+                this.task = task;
+                Counter = delayTicks;
+            }
+
+            /// <summary>
+            /// Tick the counter
+            /// </summary>
+            /// <returns>Return true if counted to zero</returns>
+            public bool Tick()
+            {
+                Counter--;
+                if (Counter <= 0)
+                    return true;
+                return false;
+            }
+
+            /// <summary>
+            /// Execute the task
+            /// </summary>
+            public void Execute()
+            {
+                if (task != null)
+                {
+                    task();
+                }
             }
         }
     }

--- a/MinecraftClient/McClient.cs
+++ b/MinecraftClient/McClient.cs
@@ -28,10 +28,12 @@ namespace MinecraftClient
         private readonly Dictionary<Guid, string> onlinePlayers = new Dictionary<Guid, string>();
 
         private static bool commandsLoaded = false;
-        private Queue<string> commandQueue = new Queue<string>();
 
         private Queue<string> chatQueue = new Queue<string>();
         private static DateTime nextMessageSendTime = DateTime.MinValue;
+
+        private Action threadTasks;
+        private object threadTasksLock = new object();
 
         private readonly List<ChatBot> bots = new List<ChatBot>();
         private static readonly List<ChatBot> botsOnHold = new List<ChatBot>();
@@ -310,10 +312,7 @@ namespace MinecraftClient
                 while (client.Client.Connected)
                 {
                     string text = ConsoleIO.ReadLine();
-                    lock (commandQueue)
-                    {
-                        commandQueue.Enqueue(text);
-                    }
+                    ScheduleTask(delegate () { HandleCommandPromptText(text); });
                 }   
             }
             catch (IOException) { }
@@ -592,14 +591,6 @@ namespace MinecraftClient
                 }
             }
 
-            lock (commandQueue)
-            {
-                if (commandQueue.Count > 0)
-                {
-                    HandleCommandPromptText(commandQueue.Dequeue());
-                }
-            }
-
             lock (chatQueue)
             {
                 if (chatQueue.Count > 0 && nextMessageSendTime < DateTime.Now)
@@ -650,6 +641,15 @@ namespace MinecraftClient
                 if (respawnTicks == 0)
                     SendRespawnPacket();
             }
+
+            if (threadTasks != null)
+            {
+                lock (threadTasksLock)
+                {
+                    threadTasks();
+                    threadTasks = null;
+                }
+            }
         }
 
         /// <summary>
@@ -692,6 +692,18 @@ namespace MinecraftClient
                 return true;
             }
             else return false;
+        }
+
+        /// <summary>
+        /// Schedule a task to run on the main thread
+        /// </summary>
+        /// <param name="task">Task to run</param>
+        public void ScheduleTask(Action task)
+        {
+            lock (threadTasksLock)
+            {
+                threadTasks += task;
+            }
         }
 
         #region Management: Load/Unload ChatBots and Enable/Disable settings

--- a/MinecraftClient/McClient.cs
+++ b/MinecraftClient/McClient.cs
@@ -580,6 +580,7 @@ namespace MinecraftClient
                 try
                 {
                     bot.Update();
+                    bot.UpdateInternal();
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
Taking command input as example, scheduling a task to run is better than creating a queue for everything that need to be run on the main thread.

#

My next plan is to create a method to schedule a delayed task for `ChatBot` API so that delaying a task will be easier.
https://github.com/ORelio/Minecraft-Console-Client/blob/0400ad89acf2aa3fad985ce45afbefda2d90db1d/MinecraftClient/ChatBots/AutoAttack.cs#L70-L73
https://github.com/ORelio/Minecraft-Console-Client/blob/0400ad89acf2aa3fad985ce45afbefda2d90db1d/MinecraftClient/ChatBots/AutoFishing.cs#L35-L42