### PR TITLE
Implement hardcoding the WebhookURL

### DIFF
--- a/MinecraftClient/config/ChatBots/DiscordWebhook.cs
+++ b/MinecraftClient/config/ChatBots/DiscordWebhook.cs
@@ -78,7 +78,7 @@ class WebhoookSettings
         skinModes.Add("fullSkin", "https://crafatar.com/renders/body/{0}");
 
         // Define standard values for main class
-        WebhookURL = "Your URL";
+        WebhookURL = "Your URL";                // Enter your Webhook URL here to start the bot with it predefined.
         SendPrivateMsg = true;
         CustomChatDetection = true;
         SendServerMsg = true;

--- a/MinecraftClient/config/ChatBots/DiscordWebhook.cs
+++ b/MinecraftClient/config/ChatBots/DiscordWebhook.cs
@@ -78,7 +78,7 @@ class WebhoookSettings
         skinModes.Add("fullSkin", "https://crafatar.com/renders/body/{0}");
 
         // Define standard values for main class
-		WebhookURL = "Your URL";
+        WebhookURL = "Your URL";
         SendPrivateMsg = true;
         CustomChatDetection = true;
         SendServerMsg = true;

--- a/MinecraftClient/config/ChatBots/DiscordWebhook.cs
+++ b/MinecraftClient/config/ChatBots/DiscordWebhook.cs
@@ -78,6 +78,7 @@ class WebhoookSettings
         skinModes.Add("fullSkin", "https://crafatar.com/renders/body/{0}");
 
         // Define standard values for main class
+		WebhookURL = "Your URL";
         SendPrivateMsg = true;
         CustomChatDetection = true;
         SendServerMsg = true;
@@ -427,7 +428,7 @@ class DiscordWebhook : ChatBot
     {
         msg.Content += " " + AddPingsToMessage(msg.SenderName, msg.Content);
 
-        if (settings.WebhookURL != "" && settings.WebhookURL != null)
+        if (settings.WebhookURL != "" && settings.WebhookURL != "Your URL")
         {
             LogDebugToConsole("Send webhook request to Discord.");
             try


### PR DESCRIPTION
This is not a very smooth way of implementing the automatic start of the script with a URL. But as it was requested, I added it. I would rather prefere doing this with a script, which calls the bot and after that executes the "/dw changeurl" command.

A better way of implementation would be to add start parameters like "/script discordwebhook WebhookURL", which automatically starts the script with the URL. Unfortunately I could not find a way to read the arguments provided while calling the script.