### PR TITLE
Use dedicated thread to process world data

### DIFF
--- a/MinecraftClient/McClient.cs
+++ b/MinecraftClient/McClient.cs
@@ -699,6 +699,7 @@ namespace MinecraftClient
         /// Schedule a task to run on the main thread
         /// </summary>
         /// <param name="task">Task to run</param>
+        /// <returns>Any result returned from delegate</returns>
         public object ScheduleTask(Delegate task)
         {
             var taskAndResult = new TaskWithResult(task);

--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -18,6 +18,7 @@ using System.Diagnostics;
 using MinecraftClient.Inventory.ItemPalettes;
 using MinecraftClient.Protocol.Handlers.PacketPalettes;
 using MinecraftClient.Logger;
+using System.Threading.Tasks;
 
 namespace MinecraftClient.Protocol.Handlers
 {
@@ -422,7 +423,10 @@ namespace MinecraftClient.Protocol.Handlers
                                 int compressedDataSize = dataTypes.ReadNextInt(packetData);
                                 byte[] compressed = dataTypes.ReadData(compressedDataSize, packetData);
                                 byte[] decompressed = ZlibUtils.Decompress(compressed);
-                                pTerrain.ProcessChunkColumnData(chunkX, chunkZ, chunkMask, addBitmap, currentDimension == 0, chunksContinuous, currentDimension, new Queue<byte>(decompressed));
+                                new Task(new Action(() =>
+                                {
+                                    pTerrain.ProcessChunkColumnData(chunkX, chunkZ, chunkMask, addBitmap, currentDimension == 0, chunksContinuous, currentDimension, new Queue<byte>(decompressed));
+                                })).Start();
                             }
                             else
                             {
@@ -446,7 +450,10 @@ namespace MinecraftClient.Protocol.Handlers
                                     else dataTypes.ReadData(1024 * 4, packetData); // Biomes - 1.15 and above
                                 }
                                 int dataSize = dataTypes.ReadNextVarInt(packetData);
-                                pTerrain.ProcessChunkColumnData(chunkX, chunkZ, chunkMask, 0, false, chunksContinuous, currentDimension, packetData);
+                                new Task(new Action(() =>
+                                {
+                                    pTerrain.ProcessChunkColumnData(chunkX, chunkZ, chunkMask, 0, false, chunksContinuous, currentDimension, packetData);
+                                })).Start();
                             }
                         }
                         break;

--- a/MinecraftClient/Protocol/Handlers/Protocol18Terrain.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18Terrain.cs
@@ -162,9 +162,12 @@ namespace MinecraftClient.Protocol.Handlers
                         }
 
                         //We have our chunk, save the chunk into the world
-                        if (handler.GetWorld()[chunkX, chunkZ] == null)
-                            handler.GetWorld()[chunkX, chunkZ] = new ChunkColumn();
-                        handler.GetWorld()[chunkX, chunkZ][chunkY] = chunk;
+                        handler.ScheduleTask(new Action(() => 
+                        {
+                            if (handler.GetWorld()[chunkX, chunkZ] == null)
+                                handler.GetWorld()[chunkX, chunkZ] = new ChunkColumn();
+                            handler.GetWorld()[chunkX, chunkZ][chunkY] = chunk;
+                        }));
 
                         //Pre-1.14 Lighting data
                         if (protocolversion < Protocol18Handler.MC114Version)
@@ -189,7 +192,10 @@ namespace MinecraftClient.Protocol.Handlers
                 if (chunksContinuous && chunkMask == 0)
                 {
                     //Unload the entire chunk column
-                    handler.GetWorld()[chunkX, chunkZ] = null;
+                    handler.ScheduleTask(new Action(() =>
+                    {
+                        handler.GetWorld()[chunkX, chunkZ] = null;
+                    }));
                 }
                 else
                 {
@@ -208,9 +214,12 @@ namespace MinecraftClient.Protocol.Handlers
                                         chunk[blockX, blockY, blockZ] = new Block(queue.Dequeue());
 
                             //We have our chunk, save the chunk into the world
-                            if (handler.GetWorld()[chunkX, chunkZ] == null)
-                                handler.GetWorld()[chunkX, chunkZ] = new ChunkColumn();
-                            handler.GetWorld()[chunkX, chunkZ][chunkY] = chunk;
+                            handler.ScheduleTask(new Action(() =>
+                            {
+                                if (handler.GetWorld()[chunkX, chunkZ] == null)
+                                    handler.GetWorld()[chunkX, chunkZ] = new ChunkColumn();
+                                handler.GetWorld()[chunkX, chunkZ][chunkY] = chunk;
+                            }));
                         }
                     }
 
@@ -239,7 +248,10 @@ namespace MinecraftClient.Protocol.Handlers
                 if (chunksContinuous && chunkMask == 0)
                 {
                     //Unload the entire chunk column
-                    handler.GetWorld()[chunkX, chunkZ] = null;
+                    handler.ScheduleTask(new Action(() =>
+                    {
+                        handler.GetWorld()[chunkX, chunkZ] = null;
+                    }));
                 }
                 else
                 {
@@ -285,9 +297,12 @@ namespace MinecraftClient.Protocol.Handlers
                                     for (int blockX = 0; blockX < Chunk.SizeX; blockX++)
                                         chunk[blockX, blockY, blockZ] = new Block(blockTypes.Dequeue(), blockMeta.Dequeue());
 
-                            if (handler.GetWorld()[chunkX, chunkZ] == null)
-                                handler.GetWorld()[chunkX, chunkZ] = new ChunkColumn();
-                            handler.GetWorld()[chunkX, chunkZ][chunkY] = chunk;
+                            handler.ScheduleTask(new Action(() =>
+                            {
+                                if (handler.GetWorld()[chunkX, chunkZ] == null)
+                                    handler.GetWorld()[chunkX, chunkZ] = new ChunkColumn();
+                                handler.GetWorld()[chunkX, chunkZ][chunkY] = chunk;
+                            }));
                         }
                     }
                 }

--- a/MinecraftClient/Protocol/IMinecraftComHandler.cs
+++ b/MinecraftClient/Protocol/IMinecraftComHandler.cs
@@ -41,6 +41,13 @@ namespace MinecraftClient.Protocol
         ILogger GetLogger();
 
         /// <summary>
+        /// Schedule a task to run on the main thread
+        /// </summary>
+        /// <param name="task">Task to run</param>
+        /// <returns>Any result returned from delegate</returns>
+        object ScheduleTask(Delegate task);
+
+        /// <summary>
         /// Called when a network packet received or sent
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
This change allow low-end device to join server without being timeout. I decided not to change `/move` command as it doesn't cause connection timeout.

Tested with Raspberry Pi 4 4GB. It is possible to join server with `terrainandmovement` enabled now.

Resolve #1583