### PR TITLE
Remove illegal character in text message before sending

### DIFF
--- a/MinecraftClient/ChatBots/RemoteControl.cs
+++ b/MinecraftClient/ChatBots/RemoteControl.cs
@@ -19,6 +19,11 @@ namespace MinecraftClient.ChatBots
             {
                 string response = "";
                 PerformInternalCommand(command, ref response);
+                response = GetVerbatim(response);
+                foreach (char disallowedChar in McClient.GetDisallowedChatCharacters())
+                {
+                    response = response.Replace(disallowedChar.ToString(), String.Empty);
+                }
                 if (response.Length > 0)
                 {
                     SendPrivateMessage(sender, response);

--- a/MinecraftClient/McClient.cs
+++ b/MinecraftClient/McClient.cs
@@ -710,6 +710,15 @@ namespace MinecraftClient
             return taskAndResult.Result;
         }
 
+        /// <summary>
+        /// Get a list of disallowed characters in chat
+        /// </summary>
+        /// <returns></returns>
+        public static char[] GetDisallowedChatCharacters()
+        {
+            return new char[] { (char)167, (char)127 }; // Minecraft color code and ASCII code DEL
+        }
+
         #region Management: Load/Unload ChatBots and Enable/Disable settings
 
         /// <summary>
@@ -996,6 +1005,12 @@ namespace MinecraftClient
         {
             lock (chatQueue)
             {
+                foreach (char disallowedChar in GetDisallowedChatCharacters())
+                {
+                    text = text.Replace(disallowedChar.ToString(), String.Empty);
+                }
+                if (String.IsNullOrEmpty(text))
+                    return;
                 int maxLength = handler.GetMaxChatMessageLength();
                 if (text.Length > maxLength) //Message is too long?
                 {

--- a/MinecraftClient/McClient.cs
+++ b/MinecraftClient/McClient.cs
@@ -1005,10 +1005,6 @@ namespace MinecraftClient
         {
             lock (chatQueue)
             {
-                foreach (char disallowedChar in GetDisallowedChatCharacters())
-                {
-                    text = text.Replace(disallowedChar.ToString(), String.Empty);
-                }
                 if (String.IsNullOrEmpty(text))
                     return;
                 int maxLength = handler.GetMaxChatMessageLength();


### PR DESCRIPTION
Sending illegal character will cause server to kick the client. This happens when using remote control to execute some command that contains color output.

Corresponding checking code in minecraft server source code:
```java
public static boolean isAllowedChatCharacter(char c0) {
    return c0 != 167 && c0 >= ' ' && c0 != 127;
}
```

@ORelio If this looks good please merge it directly.