### PR TITLE
Prevent errors from OnPlayerLeave() returning NULL

### DIFF
--- a/MinecraftClient/config/ChatBots/DiscordWebhook.cs
+++ b/MinecraftClient/config/ChatBots/DiscordWebhook.cs
@@ -317,17 +317,33 @@ class DiscordWebhook : ChatBot
 
     public override void OnPlayerJoin(Guid uuid, string name)
     {
-        if (settings.GetNamesToUuidMojangCache().ContainsKey(name))
+        if (uuid.ToString() != string.Empty && name != string.Empty &&
+            uuid.ToString() != null && name != null)
         {
-            settings.GetNamesToUuidMojangCache().Remove(name);
+            if (settings.GetNamesToUuidMojangCache().ContainsKey(name))
+            {
+                settings.GetNamesToUuidMojangCache().Remove(name);
+            }
+        }
+        else
+        {
+            LogDebugToConsole(string.Format("Invalid player joined the game! UUID: {0}, Playername: {1}", uuid.ToString(), name));
         }
     }
 
     public override void OnPlayerLeave(Guid uuid, string name)
     {
-        if (!settings.GetNamesToUuidMojangCache().ContainsKey(name))
+        if (uuid.ToString() != string.Empty && name != string.Empty &&
+            uuid.ToString() != null && name != null)
         {
-            settings.GetNamesToUuidMojangCache().Add(name, uuid.ToString());
+            if (!settings.GetNamesToUuidMojangCache().ContainsKey(name))
+            {
+                settings.GetNamesToUuidMojangCache().Add(name, uuid.ToString());
+            }
+        }
+        else
+        {
+            LogDebugToConsole(string.Format("Invalid player left the game! UUID: {0}, Playername: {1}", uuid.ToString(), name));
         }
     }
 
@@ -768,4 +784,3 @@ class DiscordWebhook : ChatBot
         else { return GetHelp(); }
     }
 }
-


### PR DESCRIPTION
I suffered from some errors when I started the script. I soon found out, that the client detects some players leaving and I was wondering why, because there was not even a leaving message. I soon found out that the errors came from OnPlayerLeave() which returned a UUID but the name parameter was NULL. I don't know whether this is a bug in the client, but this should fix it for the script.