### PR TITLE
Addition to MojangAPI.cs

### DIFF
--- a/MinecraftClient/Protocol/MojangAPI.cs
+++ b/MinecraftClient/Protocol/MojangAPI.cs
@@ -207,15 +207,27 @@ namespace MinecraftClient.Protocol
         /// <returns>True if the default model for this UUID is Alex</returns>
         public static bool DefaultModelAlex(string uuid)
         {
-            // Evaluate whether a number is even.
-            Func<int, bool> isEven = x => x % 2 == 0;
+            return hashCode(uuid) % 2 == 1;
+        }
 
-            // Whether the player has the “Alex?” or “Steve?” skin depends on the Java hashCode of their UUID. 
-            // Steve is used for even hashes.
-            return isEven(Int16.Parse(uuid[7].ToString(), System.Globalization.NumberStyles.AllowHexSpecifier)) ^
-                isEven(Int16.Parse(uuid[15].ToString(), System.Globalization.NumberStyles.AllowHexSpecifier)) ^
-                isEven(Int16.Parse(uuid[23].ToString(), System.Globalization.NumberStyles.AllowHexSpecifier)) ^
-                isEven(Int16.Parse(uuid[31].ToString(), System.Globalization.NumberStyles.AllowHexSpecifier));
+        /// <summary>
+        /// Creates the hash of an UUID
+        /// </summary>
+        /// <param name="hash">UUID of a player.</param>
+        /// <returns></returns>
+        private static int hashCode(string hash)
+        {
+            byte[] data = GuidExtensions.ToLittleEndian(new Guid(hash)).ToByteArray();
+
+            ulong msb = 0;
+            ulong lsb = 0;
+            for (int i = 0; i < 8; i++)
+                msb = (msb << 8) | (uint)(data[i] & 0xff);
+            for (int i = 8; i < 16; i++)
+                lsb = (lsb << 8) | (uint)(data[i] & 0xff);
+            var hilo = msb ^ lsb;
+
+            return ((int)(hilo >> 32)) ^ (int)hilo;
         }
     }
 }

--- a/MinecraftClient/Protocol/MojangAPI.cs
+++ b/MinecraftClient/Protocol/MojangAPI.cs
@@ -6,6 +6,7 @@ using System.Net;
 /// By using these functions you agree to the ToS of the Mojang API.
 /// You should note that all public APIs are rate limited so you are expected to cache the results. 
 /// This is currently set at 600 requests per 10 minutes but this may change.
+/// Source: https://wiki.vg/Mojang_API
 /// !!! ATTENTION !!!
 
 namespace MinecraftClient.Protocol
@@ -94,7 +95,7 @@ namespace MinecraftClient.Protocol
                     // DateTimeOffset creationDate = DateTimeOffset.FromUnixTimeMilliseconds(Convert.ToInt64(jsonData.Properties["changedToAt"].StringValue));
                     //
 
-                    // Workaround for converting Unix time to normal time
+                    // Workaround for converting Unix time to normal time.
                     DateTimeOffset creationDate = unixTimeStampToDateTime(Convert.ToDouble(jsonData.Properties["changedToAt"].StringValue));
 
                     // Add Keyvaluepair to dict.
@@ -171,20 +172,24 @@ namespace MinecraftClient.Protocol
             textureDict = decodedJsonSkinInfo.Properties["textures"].Properties;
 
             // Can apparently be missing, if no custom skin is set.
-            // Probably for completely new accounts.
+            // Probably for completely new accounts. 
+            // (Still exists after changing back to Steve or Alex skin.)
             if (textureDict.ContainsKey("SKIN"))
             {
                 // Add the URL leading to the texture of the ingame skin.
                 tempDict.Add("SkinURL", textureDict["SKIN"].Properties.ContainsKey("url") ? textureDict["SKIN"].Properties["url"].StringValue : string.Empty);
 
                 // Detect whether the playermodel is based on Steve or Alex.
-                // If the skin property contains metadata, wich always contains "slim", it is an Alex based skin.
+                // If the skin property contains metadata, which always contains "slim", it is an Alex based skin.
                 tempDict.Add("PlayerModel", textureDict["SKIN"].Properties.ContainsKey("metadata") ? "Alex" : "Steve");
             }
+            // Tested it on several players, this case never occured.
             else
             {
-                // Enter an empty URL if nothing is provided.
+                // This player has assumingly never changed their skin.
+                // Probably a completely new account.
                 tempDict.Add("SkinURL", string.Empty);
+                tempDict.Add("PlayerModel", DefaultModelAlex(uuid) ? "Alex" : "Steve");
             }
 
             // If a cape exists, add it, otherwise leave string empty.
@@ -192,6 +197,25 @@ namespace MinecraftClient.Protocol
                 textureDict.ContainsKey("CAPE") ? textureDict["CAPE"].Properties["url"].StringValue : string.Empty);
 
             return tempDict;
+        }
+
+        /// <summary>
+        /// Gets the playermodel that is assigned to the account by default. 
+        /// (Before the skin is changed for the first time.)
+        /// </summary>
+        /// <param name="uuid">UUID of a Player</param>
+        /// <returns>True if the default model for this UUID is Alex</returns>
+        public static bool DefaultModelAlex(string uuid)
+        {
+            // Evaluate whether a number is even.
+            Func<int, bool> isEven = x => x % 2 == 0;
+
+            // Whether the player has the “Alex?” or “Steve?” skin depends on the Java hashCode of their UUID. 
+            // Steve is used for even hashes.
+            return isEven(Int16.Parse(uuid[7].ToString(), System.Globalization.NumberStyles.AllowHexSpecifier)) ^
+                isEven(Int16.Parse(uuid[15].ToString(), System.Globalization.NumberStyles.AllowHexSpecifier)) ^
+                isEven(Int16.Parse(uuid[23].ToString(), System.Globalization.NumberStyles.AllowHexSpecifier)) ^
+                isEven(Int16.Parse(uuid[31].ToString(), System.Globalization.NumberStyles.AllowHexSpecifier));
         }
     }
 }

--- a/MinecraftClient/Protocol/MojangAPI.cs
+++ b/MinecraftClient/Protocol/MojangAPI.cs
@@ -11,6 +11,9 @@ using System.Net;
 
 namespace MinecraftClient.Protocol
 {
+    // Enum to display the status of different services
+    public enum ServiceStatus { red, yellow, green };
+
     /// <summary>
     /// Information about a players Skin.
     /// Empty string if not available.
@@ -34,16 +37,23 @@ namespace MinecraftClient.Protocol
     /// </summary>
     public class MojangServiceStatus
     {
-        public readonly string MinecraftNet;
-        public readonly string SessionMinecraftNet;
-        public readonly string AccountMojangCom;
-        public readonly string AuthserverMojangCom;
-        public readonly string SessionserverMojangCom;
-        public readonly string ApiMojangCom;
-        public readonly string TexturesMinecraftNet;
-        public readonly string MojangCom;
+        public readonly ServiceStatus MinecraftNet;
+        public readonly ServiceStatus SessionMinecraftNet;
+        public readonly ServiceStatus AccountMojangCom;
+        public readonly ServiceStatus AuthserverMojangCom;
+        public readonly ServiceStatus SessionserverMojangCom;
+        public readonly ServiceStatus ApiMojangCom;
+        public readonly ServiceStatus TexturesMinecraftNet;
+        public readonly ServiceStatus MojangCom;
 
-        public MojangServiceStatus(string minecraftNet = "", string sessionMinecraftNet = "", string accountMojangCom = "", string authserverMojangCom = "", string sessionserverMojangCom = "", string apiMojangCom = "", string texturesMinecraftNet = "", string mojangCom = "")
+        public MojangServiceStatus(ServiceStatus minecraftNet = ServiceStatus.red,
+            ServiceStatus sessionMinecraftNet = ServiceStatus.red,
+            ServiceStatus accountMojangCom = ServiceStatus.red,
+            ServiceStatus authserverMojangCom = ServiceStatus.red,
+            ServiceStatus sessionserverMojangCom = ServiceStatus.red,
+            ServiceStatus apiMojangCom = ServiceStatus.red,
+            ServiceStatus texturesMinecraftNet = ServiceStatus.red,
+            ServiceStatus mojangCom = ServiceStatus.red)
         {
             MinecraftNet = minecraftNet;
             SessionMinecraftNet = sessionMinecraftNet;
@@ -79,6 +89,26 @@ namespace MinecraftClient.Protocol
             return dateTime;
         }
         // Can be removed in newer C# versions.
+
+        /// <summary>
+        /// Converts a string to a ServiceStatus enum.
+        /// </summary>
+        /// <param name="s">string to convert</param>
+        /// <returns>ServiceStatus enum, red as default.</returns>
+        private static ServiceStatus stringToServiceStatus(string s)
+        {
+            ServiceStatus servStat;
+
+            if (Enum.TryParse(s, out servStat))
+            {
+                return servStat;
+            }
+            else
+            {
+                // return red as standard value.
+                return ServiceStatus.red;
+            }
+        }
 
         /// <summary>
         /// Obtain the UUID of a Player through its name
@@ -172,14 +202,15 @@ namespace MinecraftClient.Protocol
             }
             catch (Exception) { new MojangServiceStatus(); }
 
-            return new MojangServiceStatus(minecraftNet: jsonDataList[0].Properties["minecraft.net"].StringValue,
-                sessionMinecraftNet: jsonDataList[1].Properties["session.minecraft.net"].StringValue,
-                accountMojangCom: jsonDataList[2].Properties["account.mojang.com"].StringValue,
-                authserverMojangCom: jsonDataList[3].Properties["authserver.mojang.com"].StringValue,
-                sessionserverMojangCom: jsonDataList[4].Properties["sessionserver.mojang.com"].StringValue,
-                apiMojangCom: jsonDataList[5].Properties["api.mojang.com"].StringValue,
-                texturesMinecraftNet: jsonDataList[6].Properties["textures.minecraft.net"].StringValue,
-                mojangCom: jsonDataList[7].Properties["mojang.com"].StringValue
+            // Convert string to enum values and store them inside a MojangeServiceStatus object.
+            return new MojangServiceStatus(minecraftNet: stringToServiceStatus(jsonDataList[0].Properties["minecraft.net"].StringValue),
+                sessionMinecraftNet: stringToServiceStatus(jsonDataList[1].Properties["session.minecraft.net"].StringValue),
+                accountMojangCom: stringToServiceStatus(jsonDataList[2].Properties["account.mojang.com"].StringValue),
+                authserverMojangCom: stringToServiceStatus(jsonDataList[3].Properties["authserver.mojang.com"].StringValue),
+                sessionserverMojangCom: stringToServiceStatus(jsonDataList[4].Properties["sessionserver.mojang.com"].StringValue),
+                apiMojangCom: stringToServiceStatus(jsonDataList[5].Properties["api.mojang.com"].StringValue),
+                texturesMinecraftNet: stringToServiceStatus(jsonDataList[6].Properties["textures.minecraft.net"].StringValue),
+                mojangCom: stringToServiceStatus(jsonDataList[7].Properties["mojang.com"].StringValue)
                 );
         }
 


### PR DESCRIPTION
It seems like I have overseen something. In the Mojang API there is a way to request a players profile. Between several useless information, there is a Base64 encrypted JSON string, which reveals plenty information about the players skin and look. I implemented this feature, but I was a bit confused when it comes to a certain edge case:

There is a possibility, that a a player has no skin data. According to the [wiki](https://wiki.vg/Mojang_API) this happens when a Player has not set a custom skin. Seemingly this only applies until the first skin change of an account, since I was not able to recreate this, by changing my skin to Steve. If these cases occur, you can still evaluate their skin by checking their UUID, since even UUIDs have a Steve skin and odd ones an Alex skin.

I am not sure whether I implemented the odd/even check correctly, as I was mainly orienting on a JS [source](https://github.com/crafatar/crafatar/blob/9d2fe0c45424de3ebc8e0b10f9446e7d5c3738b2/lib/skins.js#L90-L108) recommended by the wiki.