### PR TITLE
Update Github Actions to be more robust with releases

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -197,6 +197,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: artifacts/
+          merge-multiple: true
           
       - name: Create Release
         uses: ncipollo/release-action@v1.14.0


### PR DESCRIPTION
The old build had issues with tag creation and race conditions, since each runner pushed their artifact to Github simultaneously, they would complain about either missing tags, existing tags, or other tag related issue.

This update cleans up the workflow and introduces two new stages, the create-tag and create-release jobs.

The build stages are now as follows:
Determine Build -> Create Tag/Fetch Translations -> Build -> Create Release

The Create Tag stage will be the one responsible for creating the tag and build number, and pass it downstream to the other stages.
The Build stage will now upload all artifacts to Github Actions instead of directly interacting with the releases.
The final Create Release stage will merge all the artifacts and upload them all at once to prevent issues with creating releases.