### PR TITLE
feat+bugfix: Updated the code base to use C# 14 features + Fixed inventory crash on 1.13/.1/.2

### DIFF
--- a/MinecraftClient/ChatBots/AutoCraft.cs
+++ b/MinecraftClient/ChatBots/AutoCraft.cs
@@ -123,7 +123,7 @@ namespace MinecraftClient.ChatBots
 
             public enum OnFailConfig { abort, wait }
 
-            public class RecipeConfig
+            public record RecipeConfig
             {
                 public string Name = "Recipe Name";
 
@@ -241,7 +241,7 @@ namespace MinecraftClient.ChatBots
         /// <summary>
         /// Represent a crafting recipe
         /// </summary>
-        private class Recipe
+        private record Recipe
         {
             /// <summary>
             /// The results item of this recipe
@@ -276,7 +276,7 @@ namespace MinecraftClient.ChatBots
             /// <remarks>so that it can be used in crafting table</remarks>
             public static Recipe ConvertToCraftingTable(Recipe recipe)
             {
-                if (recipe.CraftingAreaType == ContainerType.PlayerInventory && recipe.Materials != null)
+                if (recipe.CraftingAreaType == ContainerType.PlayerInventory && recipe.Materials is not null)
                 {
                     if (recipe.Materials.ContainsKey(4))
                     {
@@ -500,7 +500,7 @@ namespace MinecraftClient.ChatBots
                 }
             }
 
-            if (recipe.Materials != null)
+            if (recipe.Materials is not null)
             {
                 foreach (KeyValuePair<int, ItemType> slot in recipe.Materials)
                 {

--- a/MinecraftClient/ChatBots/AutoDig.cs
+++ b/MinecraftClient/ChatBots/AutoDig.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Brigadier.NET.Builder;
 using MinecraftClient.CommandHandler;
 using MinecraftClient.CommandHandler.Patch;
@@ -102,7 +103,7 @@ namespace MinecraftClient.ChatBots
         private bool inventoryEnabled;
 
         private int counter = 0;
-        private readonly object stateLock = new();
+        private readonly Lock stateLock = new();
         private State state = State.WaitJoinGame;
 
         bool AlreadyWaitting = false;

--- a/MinecraftClient/ChatBots/AutoFishing.cs
+++ b/MinecraftClient/ChatBots/AutoFishing.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using Brigadier.NET.Builder;
 using MinecraftClient.CommandHandler;
 using MinecraftClient.CommandHandler.Patch;
@@ -175,7 +176,7 @@ namespace MinecraftClient.ChatBots
         private Entity fishItem = new(-1, EntityType.Item, Location.Zero);
 
         private int counter = 0;
-        private readonly object stateLock = new();
+        private readonly Lock stateLock = new();
         private FishingState state = FishingState.WaitJoinGame;
 
         private int curLocationIdx = 0, moveDir = 1;
@@ -473,7 +474,7 @@ namespace MinecraftClient.ChatBots
 
         public override void OnEntityDespawn(Entity entity)
         {
-            if (entity != null && fishingBobber != null && entity.Type == EntityType.FishingBobber && entity.ID == fishingBobber!.ID)
+            if (entity is not null && fishingBobber is not null && entity.Type == EntityType.FishingBobber && entity.ID == fishingBobber!.ID)
             {
                 if (Config.Log_Fish_Bobber)
                     LogToConsole(string.Format("FishingBobber despawn at {0}", entity.Location));
@@ -498,7 +499,7 @@ namespace MinecraftClient.ChatBots
 
         public override void OnEntityMove(Entity entity)
         {
-            if (isFishing && entity != null && fishingBobber!.ID == entity.ID &&
+            if (isFishing && entity is not null && fishingBobber!.ID == entity.ID &&
                 (state == FishingState.WaitingFishToBite || state == FishingState.WaitingFishingBobber))
             {
                 Location Pos = entity.Location;
@@ -602,12 +603,12 @@ namespace MinecraftClient.ChatBots
 
             LocationConfig curConfig = locationList[curLocationIdx];
 
-            if (curConfig.facing != null)
+            if (curConfig.facing is not null)
                 (nextYaw, nextPitch) = ((float)curConfig.facing.Value.yaw, (float)curConfig.facing.Value.pitch);
             else
                 (nextYaw, nextPitch) = (GetYaw(), GetPitch());
 
-            if (curConfig.XYZ != null)
+            if (curConfig.XYZ is not null)
             {
                 Location current = GetCurrentLocation();
                 Location goal = new(curConfig.XYZ.Value.x, curConfig.XYZ.Value.y, curConfig.XYZ.Value.z);

--- a/MinecraftClient/ChatBots/AutoRespond.cs
+++ b/MinecraftClient/ChatBots/AutoRespond.cs
@@ -132,7 +132,7 @@ namespace MinecraftClient.ChatBots
                 if (String.IsNullOrEmpty(toSend))
                     return null;
 
-                if (regex != null)
+                if (regex is not null)
                 {
                     if (regex.IsMatch(message))
                     {
@@ -261,15 +261,15 @@ namespace MinecraftClient.ChatBots
         /// <param name="cooldown">Minimal cooldown between two matches</param>
         private void CheckAddMatch(Regex? matchRegex, string? matchString, string? matchAction, string? matchActionPrivate, string? matchActionOther, bool ownersOnly, TimeSpan cooldown)
         {
-            if (matchRegex != null || matchString != null || matchAction != null || matchActionPrivate != null || matchActionOther != null || ownersOnly || cooldown != TimeSpan.Zero)
+            if (matchRegex is not null || matchString is not null || matchAction is not null || matchActionPrivate is not null || matchActionOther is not null || ownersOnly || cooldown != TimeSpan.Zero)
             {
-                RespondRule rule = matchRegex != null
+                RespondRule rule = matchRegex is not null
                     ? new RespondRule(matchRegex, matchAction, matchActionPrivate, matchActionOther, ownersOnly, cooldown)
                     : new RespondRule(matchString, matchAction, matchActionPrivate, matchActionOther, ownersOnly, cooldown);
 
-                if (matchAction != null || matchActionPrivate != null || matchActionOther != null)
+                if (matchAction is not null || matchActionPrivate is not null || matchActionOther is not null)
                 {
-                    if (matchRegex != null || matchString != null)
+                    if (matchRegex is not null || matchString is not null)
                     {
                         respondRules!.Add(rule);
                         LogDebugToConsole(string.Format(Translations.bot_autoRespond_loaded_match, rule));

--- a/MinecraftClient/ChatBots/ChatLog.cs
+++ b/MinecraftClient/ChatBots/ChatLog.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Threading;
 using MinecraftClient.CommandHandler;
 using MinecraftClient.Scripting;
 using Tomlet.Attributes;
@@ -50,7 +51,7 @@ namespace MinecraftClient.ChatBots
         private bool saveChat = true;
         private bool savePrivate = true;
         private bool saveInternal = true;
-        private readonly object logfileLock = new();
+        private readonly Lock logfileLock = new();
 
         /// <summary>
         /// This bot saves the messages received in the specified file, with some filters and date/time tagging.

--- a/MinecraftClient/ChatBots/DiscordBridge.cs
+++ b/MinecraftClient/ChatBots/DiscordBridge.cs
@@ -153,11 +153,11 @@ namespace MinecraftClient.ChatBots
 
         private void Disconnect()
         {
-            if (discordBotClient != null)
+            if (discordBotClient is not null)
             {
                 try
                 {
-                    if (discordChannel != null)
+                    if (discordChannel is not null)
                         discordBotClient.SendMessageAsync(discordChannel, new DiscordEmbedBuilder
                         {
                             Description = Translations.bot_DiscordBridge_disconnected,
@@ -284,7 +284,7 @@ namespace MinecraftClient.ChatBots
                     filePath = filePath[(filePath.IndexOf(Path.DirectorySeparatorChar) + 1)..];
                     var messageBuilder = new DiscordMessageBuilder();
 
-                    if (text != null)
+                    if (text is not null)
                         messageBuilder.WithContent(text);
 
                     messageBuilder.AddFiles(new Dictionary<string, Stream>() { { filePath, fs } });
@@ -309,7 +309,7 @@ namespace MinecraftClient.ChatBots
 
         private bool CanSendMessages()
         {
-            return discordBotClient != null && discordChannel != null && bridgeDirection != BridgeDirection.Minecraft;
+            return discordBotClient is not null && discordChannel is not null && bridgeDirection != BridgeDirection.Minecraft;
         }
 
         async Task MainAsync()

--- a/MinecraftClient/ChatBots/DiscordRpc.cs
+++ b/MinecraftClient/ChatBots/DiscordRpc.cs
@@ -361,8 +361,8 @@ namespace MinecraftClient.ChatBots
 
             private readonly byte[] _buffer = new byte[PipeFrame.MAX_SIZE];
             private readonly Queue<PipeFrame> _frameQueue = new();
-            private readonly object _frameQueueLock = new();
-            private readonly object _streamLock = new();
+            private readonly Lock _frameQueueLock = new();
+            private readonly Lock _streamLock = new();
 
             private int _connectedPipe;
             private NamedPipeClientStream? _stream;

--- a/MinecraftClient/ChatBots/FollowPlayer.cs
+++ b/MinecraftClient/ChatBots/FollowPlayer.cs
@@ -110,13 +110,13 @@ namespace MinecraftClient.ChatBots
                 && !string.IsNullOrEmpty(entity.Name)
                 && entity.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
 
-            if (player == null)
+            if (player is null)
                 return r.SetAndReturn(CmdResult.Status.Fail, Translations.cmd_follow_invalid_player);
 
             if (!CanMoveThere(player.Location))
                 return r.SetAndReturn(CmdResult.Status.Fail, Translations.cmd_follow_cant_reach_player);
 
-            if (_playerToFollow != null && _playerToFollow.Equals(name, StringComparison.OrdinalIgnoreCase))
+            if (_playerToFollow is not null && _playerToFollow.Equals(name, StringComparison.OrdinalIgnoreCase))
                 return r.SetAndReturn(CmdResult.Status.Fail,
                     string.Format(Translations.cmd_follow_already_following, _playerToFollow));
 
@@ -127,7 +127,7 @@ namespace MinecraftClient.ChatBots
 
             var result =
                 string.Format(
-                    _playerToFollow != null ? Translations.cmd_follow_switched : Translations.cmd_follow_started,
+                    _playerToFollow is not null ? Translations.cmd_follow_switched : Translations.cmd_follow_started,
                     player.Name!);
             _playerToFollow = name.ToLower();
 
@@ -152,7 +152,7 @@ namespace MinecraftClient.ChatBots
 
         private int OnCommandStop(CmdResult r)
         {
-            if (_playerToFollow == null)
+            if (_playerToFollow is null)
                 return r.SetAndReturn(CmdResult.Status.Fail, Translations.cmd_follow_already_stopped);
 
             var movementLock = BotMovementLock.Instance;
@@ -172,7 +172,7 @@ namespace MinecraftClient.ChatBots
             if (entity.Type != EntityType.Player)
                 return;
 
-            if (_playerToFollow == null || string.IsNullOrEmpty(entity.Name))
+            if (_playerToFollow is null || string.IsNullOrEmpty(entity.Name))
                 return;
 
             if (_playerToFollow != entity.Name.ToLower())
@@ -200,7 +200,7 @@ namespace MinecraftClient.ChatBots
             if (entity.Type != EntityType.Player)
                 return;
 
-            if (_playerToFollow != null && !string.IsNullOrEmpty(entity.Name) &&
+            if (_playerToFollow is not null && !string.IsNullOrEmpty(entity.Name) &&
                 _playerToFollow.Equals(entity.Name, StringComparison.OrdinalIgnoreCase))
             {
                 LogToConsole(string.Format(Translations.cmd_follow_player_came_to_the_range, _playerToFollow));
@@ -213,7 +213,7 @@ namespace MinecraftClient.ChatBots
             if (entity.Type != EntityType.Player)
                 return;
 
-            if (_playerToFollow != null && !string.IsNullOrEmpty(entity.Name) &&
+            if (_playerToFollow is not null && !string.IsNullOrEmpty(entity.Name) &&
                 _playerToFollow.Equals(entity.Name, StringComparison.OrdinalIgnoreCase))
             {
                 LogToConsole(string.Format(Translations.cmd_follow_player_left_the_range, _playerToFollow));
@@ -223,7 +223,7 @@ namespace MinecraftClient.ChatBots
 
         public override void OnPlayerLeave(Guid uuid, string? name)
         {
-            if (_playerToFollow != null && !string.IsNullOrEmpty(name) &&
+            if (_playerToFollow is not null && !string.IsNullOrEmpty(name) &&
                 _playerToFollow.Equals(name, StringComparison.OrdinalIgnoreCase))
             {
                 LogToConsole(string.Format(Translations.cmd_follow_player_left, _playerToFollow));
@@ -235,7 +235,7 @@ namespace MinecraftClient.ChatBots
         private bool CanMoveThere(Location location)
         {
             var chunkColumn = GetWorld().GetChunkColumn(location);
-            return chunkColumn != null && chunkColumn.FullyLoaded != false;
+            return chunkColumn is not null && chunkColumn.FullyLoaded != false;
         }
     }
 }

--- a/MinecraftClient/ChatBots/Mailer.cs
+++ b/MinecraftClient/ChatBots/Mailer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using Brigadier.NET;
 using Brigadier.NET.Builder;
 using MinecraftClient.CommandHandler;
@@ -218,7 +219,7 @@ namespace MinecraftClient.ChatBots
         private IgnoreList ignoreList = new();
         private FileMonitor? mailDbFileMonitor;
         private FileMonitor? ignoreListFileMonitor;
-        private readonly object readWriteLock = new();
+        private readonly Lock readWriteLock = new();
 
         /// <summary>
         /// Initialization of the Mailer bot

--- a/MinecraftClient/ChatBots/Map.cs
+++ b/MinecraftClient/ChatBots/Map.cs
@@ -284,13 +284,13 @@ namespace MinecraftClient.ChatBots
 
             if (Config.Send_Rendered_To_Discord)
             {
-                if (discordBridge == null || (discordBridge != null && !discordBridge.IsConnected))
+                if (discordBridge is null || (discordBridge is not null && !discordBridge.IsConnected))
                     return;
             }
 
             if (Config.Send_Rendered_To_Telegram)
             {
-                if (telegramBridge == null || (telegramBridge != null && !telegramBridge.IsConnected))
+                if (telegramBridge is null || (telegramBridge is not null && !telegramBridge.IsConnected))
                     return;
             }
 

--- a/MinecraftClient/ChatBots/Script.cs
+++ b/MinecraftClient/ChatBots/Script.cs
@@ -154,7 +154,7 @@ namespace MinecraftClient.ChatBots
             if (csharp) //C# compiled script
             {
                 //Initialize thread on first update
-                if (thread == null)
+                if (thread is null)
                 {
                     thread = new Thread(() =>
                     {
@@ -166,7 +166,7 @@ namespace MinecraftClient.ChatBots
                         {
                             string errorMessage = string.Format(Translations.bot_script_fail, file, e.ExceptionType);
                             LogToConsole(errorMessage);
-                            if (owner != null)
+                            if (owner is not null)
                                 SendPrivateMessage(owner, errorMessage);
                             LogToConsole(e.InnerException);
                         }
@@ -178,7 +178,7 @@ namespace MinecraftClient.ChatBots
                 }
 
                 //Unload bot once the thread has finished running
-                if (thread != null && !thread.IsAlive)
+                if (thread is not null && !thread.IsAlive)
                 {
                     UnloadBot();
                 }

--- a/MinecraftClient/ChatBots/TelegramBridge.cs
+++ b/MinecraftClient/ChatBots/TelegramBridge.cs
@@ -148,7 +148,7 @@ namespace MinecraftClient.ChatBots
 
         private void Disconnect()
         {
-            if (botClient != null)
+            if (botClient is not null)
             {
                 try
                 {
@@ -238,7 +238,7 @@ namespace MinecraftClient.ChatBots
 
         private bool CanSendMessages()
         {
-            return botClient != null && !string.IsNullOrEmpty(Config.ChannelId.Trim()) && bridgeDirection != BridgeDirection.Minecraft;
+            return botClient is not null && !string.IsNullOrEmpty(Config.ChannelId.Trim()) && bridgeDirection != BridgeDirection.Minecraft;
         }
 
         async Task MainAsync()

--- a/MinecraftClient/ColorHelper.cs
+++ b/MinecraftClient/ColorHelper.cs
@@ -163,7 +163,7 @@ namespace MinecraftClient
         }
     }
 
-    public class ColorRGBA
+    public record struct ColorRGBA
     {
         public byte R { get; set; }
         public byte G { get; set; }

--- a/MinecraftClient/CommandHandler/ArgumentType/BotNameArgumentType.cs
+++ b/MinecraftClient/CommandHandler/ArgumentType/BotNameArgumentType.cs
@@ -17,7 +17,7 @@ namespace MinecraftClient.CommandHandler.ArgumentType
         public override Task<Suggestions> ListSuggestions<TSource>(CommandContext<TSource> context, SuggestionsBuilder builder)
         {
             McClient? client = CmdResult.currentHandler;
-            if (client != null)
+            if (client is not null)
             {
                 var botList = client.GetLoadedChatBots();
                 foreach (var bot in botList)

--- a/MinecraftClient/CommandHandler/ArgumentType/HotbarSlotArgumentType.cs
+++ b/MinecraftClient/CommandHandler/ArgumentType/HotbarSlotArgumentType.cs
@@ -18,10 +18,10 @@ namespace MinecraftClient.CommandHandler.ArgumentType
         public override Task<Suggestions> ListSuggestions<TSource>(CommandContext<TSource> context, SuggestionsBuilder builder)
         {
             McClient? client = CmdResult.currentHandler;
-            if (client != null)
+            if (client is not null)
             {
                 Inventory.Container? inventory = client.GetInventory(0);
-                if (inventory != null)
+                if (inventory is not null)
                 {
                     for (int i = 1; i <= 9; ++i)
                     {

--- a/MinecraftClient/CommandHandler/ArgumentType/InventoryIdArgumentType.cs
+++ b/MinecraftClient/CommandHandler/ArgumentType/InventoryIdArgumentType.cs
@@ -18,7 +18,7 @@ namespace MinecraftClient.CommandHandler.ArgumentType
         public override Task<Suggestions> ListSuggestions<TSource>(CommandContext<TSource> context, SuggestionsBuilder builder)
         {
             McClient? client = CmdResult.currentHandler;
-            if (client != null)
+            if (client is not null)
             {
                 var invList = client.GetInventories();
                 foreach (var inv in invList)

--- a/MinecraftClient/CommandHandler/ArgumentType/InventorySlotArgumentType.cs
+++ b/MinecraftClient/CommandHandler/ArgumentType/InventorySlotArgumentType.cs
@@ -19,7 +19,7 @@ namespace MinecraftClient.CommandHandler.ArgumentType
         public override Task<Suggestions> ListSuggestions<TSource>(CommandContext<TSource> context, SuggestionsBuilder builder)
         {
             McClient? client = CmdResult.currentHandler;
-            if (client != null && context.Nodes.Count >= 2)
+            if (client is not null && context.Nodes.Count >= 2)
             {
                 string invName = context.Nodes[1].Range.Get(builder.Input);
                 if (!int.TryParse(invName, out int invId))
@@ -33,11 +33,11 @@ namespace MinecraftClient.CommandHandler.ArgumentType
                     };
 
                 Inventory.Container? inventory = client.GetInventory(invId);
-                if (inventory != null)
+                if (inventory is not null)
                 {
                     foreach ((int slot, Inventory.Item item) in inventory.Items)
                     {
-                        if (item != null && item.Count > 0)
+                        if (item is not null && item.Count > 0)
                         {
                             string slotStr = slot.ToString();
                             if (slotStr.StartsWith(builder.RemainingLowerCase, StringComparison.InvariantCultureIgnoreCase))

--- a/MinecraftClient/CommandHandler/ArgumentType/LocationArgumentType.cs
+++ b/MinecraftClient/CommandHandler/ArgumentType/LocationArgumentType.cs
@@ -51,7 +51,7 @@ namespace MinecraftClient.CommandHandler.ArgumentType
             string[] args = builder.Remaining.Split(' ', StringSplitOptions.TrimEntries);
             if (args.Length == 0 || (args.Length == 1 && string.IsNullOrWhiteSpace(args[0])))
             {
-                if (client != null)
+                if (client is not null)
                 {
                     Location current = client.GetCurrentLocation();
                     builder.Suggest(string.Format("{0:0.00}", current.X));
@@ -68,7 +68,7 @@ namespace MinecraftClient.CommandHandler.ArgumentType
             else if (args.Length == 1 || (args.Length == 2 && string.IsNullOrWhiteSpace(args[1])))
             {
                 string add = args.Length == 1 ? " " : string.Empty;
-                if (client != null)
+                if (client is not null)
                 {
                     Location current = client.GetCurrentLocation();
                     builder.Suggest(string.Format("{0}{2}{1:0.00}", builder.Remaining, current.Y, add));
@@ -83,7 +83,7 @@ namespace MinecraftClient.CommandHandler.ArgumentType
             else if (args.Length == 2 || (args.Length == 3 && string.IsNullOrWhiteSpace(args[2])))
             {
                 string add = args.Length == 2 ? " " : string.Empty;
-                if (client != null)
+                if (client is not null)
                 {
                     Location current = client.GetCurrentLocation();
                     builder.Suggest(string.Format("{0}{2}{1:0.00}", builder.Remaining, current.Z, add));

--- a/MinecraftClient/CommandHandler/ArgumentType/MapBotMapIdArgumentType.cs
+++ b/MinecraftClient/CommandHandler/ArgumentType/MapBotMapIdArgumentType.cs
@@ -19,10 +19,10 @@ namespace MinecraftClient.CommandHandler.ArgumentType
         public override Task<Suggestions> ListSuggestions<TSource>(CommandContext<TSource> context, SuggestionsBuilder builder)
         {
             McClient? client = CmdResult.currentHandler;
-            if (client != null)
+            if (client is not null)
             {
                 var bot = (Map?)client.GetLoadedChatBots().Find(bot => bot.GetType().Name == "Map");
-                if (bot != null)
+                if (bot is not null)
                 {
                     var mapList = bot.cachedMaps;
                     foreach (var map in mapList)

--- a/MinecraftClient/CommandHandler/ArgumentType/PlayerNameArgumentType.cs
+++ b/MinecraftClient/CommandHandler/ArgumentType/PlayerNameArgumentType.cs
@@ -19,7 +19,7 @@ namespace MinecraftClient.CommandHandler.ArgumentType
         public override Task<Suggestions> ListSuggestions<TSource>(CommandContext<TSource> context, SuggestionsBuilder builder)
         {
             McClient? client = CmdResult.currentHandler;
-            if (client != null)
+            if (client is not null)
             {
                 var entityList = client.GetEntities().Values.ToList();
                 foreach (var entity in entityList)

--- a/MinecraftClient/CommandHandler/CmdResult.cs
+++ b/MinecraftClient/CommandHandler/CmdResult.cs
@@ -87,7 +87,7 @@ namespace MinecraftClient.CommandHandler
 
         public override string ToString()
         {
-            if (result != null)
+            if (result is not null)
                 return result;
             else
                 return status.ToString();

--- a/MinecraftClient/CommandHandler/SuggestionTooltip.cs
+++ b/MinecraftClient/CommandHandler/SuggestionTooltip.cs
@@ -2,13 +2,8 @@
 
 namespace MinecraftClient.CommandHandler
 {
-    internal class SuggestionTooltip : IMessage
+    internal class SuggestionTooltip(string tooltip) : IMessage
     {
-        public SuggestionTooltip(string tooltip)
-        {
-            String = tooltip;
-        }
-
-        public string String { get; set; }
+        public string String { get; set; } = tooltip;
     }
 }

--- a/MinecraftClient/Commands/Bots.cs
+++ b/MinecraftClient/Commands/Bots.cs
@@ -84,7 +84,7 @@ namespace MinecraftClient.Commands
             else
             {
                 ChatBot? bot = handler.GetLoadedChatBots().Find(bot => bot.GetType().Name.ToLower() == botName.ToLower());
-                if (bot == null)
+                if (bot is null)
                     return r.SetAndReturn(CmdResult.Status.Fail, string.Format(Translations.cmd_bots_notfound, botName));
                 else
                 {

--- a/MinecraftClient/Commands/Chunk.cs
+++ b/MinecraftClient/Commands/Chunk.cs
@@ -92,7 +92,7 @@ namespace MinecraftClient.Commands
             sb.Append('\n');
 
             sb.AppendLine(string.Format(Translations.cmd_chunk_current, current, current.ChunkX, current.ChunkZ));
-            if (markedChunkPos != null)
+            if (markedChunkPos is not null)
             {
                 sb.Append(Translations.cmd_chunk_marked);
                 if (pos.HasValue)
@@ -120,7 +120,7 @@ namespace MinecraftClient.Commands
             {
                 for (int x = startX; x <= endX; ++x)
                 {
-                    if (world[x, z] != null)
+                    if (world[x, z] is not null)
                     {
                         leftMost = Math.Min(leftMost, x);
                         rightMost = Math.Max(rightMost, x);
@@ -184,7 +184,7 @@ namespace MinecraftClient.Commands
             }
 
             // Try to include the marker chunk
-            if (markedChunkPos != null &&
+            if (markedChunkPos is not null &&
                 (((Math.Max(bottomMost, markChunkZ) - Math.Min(topMost, markChunkZ) + 1) > consoleHeight) ||
                 ((Math.Max(rightMost, markChunkX) - Math.Min(leftMost, markChunkX) + 1) > consoleWidth)))
                 sb.AppendLine(Translations.cmd_chunk_outside);
@@ -212,7 +212,7 @@ namespace MinecraftClient.Commands
                         sb.Append("§§4");           // Marked chunk: background red
 
                     ChunkColumn? chunkColumn = world[x, z];
-                    if (chunkColumn == null)
+                    if (chunkColumn is null)
                         sb.Append(chunkStatusStr[0]);
                     else if (chunkColumn.FullyLoaded)
                         sb.Append(chunkStatusStr[2]);
@@ -242,10 +242,10 @@ namespace MinecraftClient.Commands
             handler.Log.Info(Translations.cmd_chunk_for_debug);
             (int chunkX, int chunkZ) = markedChunkPos ?? new(pos!.Value.ChunkX, pos!.Value.ChunkZ);
             ChunkColumn? chunkColumn = handler.GetWorld()[chunkX, chunkZ];
-            if (chunkColumn != null)
+            if (chunkColumn is not null)
                 chunkColumn.FullyLoaded = false;
 
-            if (chunkColumn == null)
+            if (chunkColumn is null)
                 return r.SetAndReturn(Status.Fail, "Fail: chunk dosen't exist!");
             else
                 return r.SetAndReturn(Status.Done, string.Format("Successfully marked chunk ({0}, {1}) as loading.", chunkX, chunkZ));
@@ -262,10 +262,10 @@ namespace MinecraftClient.Commands
             handler.Log.Info(Translations.cmd_chunk_for_debug);
             (int chunkX, int chunkZ) = markedChunkPos ?? new(pos!.Value.ChunkX, pos!.Value.ChunkZ);
             ChunkColumn? chunkColumn = handler.GetWorld()[chunkX, chunkZ];
-            if (chunkColumn != null)
+            if (chunkColumn is not null)
                 chunkColumn.FullyLoaded = false;
 
-            if (chunkColumn == null)
+            if (chunkColumn is null)
                 return r.SetAndReturn(Status.Fail, "Fail: chunk dosen't exist!");
             else
                 return r.SetAndReturn(Status.Done, string.Format("Successfully marked chunk ({0}, {1}) as loaded.", chunkX, chunkZ));

--- a/MinecraftClient/Commands/Enchant.cs
+++ b/MinecraftClient/Commands/Enchant.cs
@@ -66,7 +66,7 @@ namespace MinecraftClient.Commands
                 }
             }
 
-            if (enchantingTable == null)
+            if (enchantingTable is null)
                 return r.SetAndReturn(CmdResult.Status.Fail, Translations.cmd_enchant_enchanting_table_not_opened);
 
             int[] emptySlots = enchantingTable.GetEmpytSlots();
@@ -84,7 +84,7 @@ namespace MinecraftClient.Commands
 
             EnchantmentData? enchantment = handler.GetLastEnchantments();
 
-            if (enchantment == null)
+            if (enchantment is null)
                 return r.SetAndReturn(CmdResult.Status.Fail, Translations.cmd_enchant_no_enchantments);
 
             short requiredLevel = slotId switch

--- a/MinecraftClient/Commands/Entitycmd.cs
+++ b/MinecraftClient/Commands/Entitycmd.cs
@@ -260,20 +260,20 @@ namespace MinecraftClient.Commands
                     sb.Append($"\n [MCC] {Translations.cmd_entityCmd_item}: {item.GetTypeString()} x{item.Count} - {displayName}§8");
             }
 
-            if (entity.Equipment.Count >= 1 && entity.Equipment != null)
+            if (entity.Equipment is not null && entity.Equipment.Count >= 1)
             {
                 sb.Append($"\n [MCC] {Translations.cmd_entityCmd_equipment}:");
-                if (entity.Equipment.ContainsKey(0) && entity.Equipment[0] != null)
+                if (entity.Equipment.ContainsKey(0) && entity.Equipment[0] is not null)
                     sb.Append($"\n   [MCC] {Translations.cmd_entityCmd_mainhand}: {entity.Equipment[0].GetTypeString()} x{entity.Equipment[0].Count}");
-                if (entity.Equipment.ContainsKey(1) && entity.Equipment[1] != null)
+                if (entity.Equipment.ContainsKey(1) && entity.Equipment[1] is not null)
                     sb.Append($"\n   [MCC] {Translations.cmd_entityCmd_offhand}: {entity.Equipment[1].GetTypeString()} x{entity.Equipment[1].Count}");
-                if (entity.Equipment.ContainsKey(5) && entity.Equipment[5] != null)
+                if (entity.Equipment.ContainsKey(5) && entity.Equipment[5] is not null)
                     sb.Append($"\n   [MCC] {Translations.cmd_entityCmd_helmet}: {entity.Equipment[5].GetTypeString()} x{entity.Equipment[5].Count}");
-                if (entity.Equipment.ContainsKey(4) && entity.Equipment[4] != null)
+                if (entity.Equipment.ContainsKey(4) && entity.Equipment[4] is not null)
                     sb.Append($"\n   [MCC] {Translations.cmd_entityCmd_chestplate}: {entity.Equipment[4].GetTypeString()} x{entity.Equipment[4].Count}");
-                if (entity.Equipment.ContainsKey(3) && entity.Equipment[3] != null)
+                if (entity.Equipment.ContainsKey(3) && entity.Equipment[3] is not null)
                     sb.Append($"\n   [MCC] {Translations.cmd_entityCmd_leggings}: {entity.Equipment[3].GetTypeString()} x{entity.Equipment[3].Count}");
-                if (entity.Equipment.ContainsKey(2) && entity.Equipment[2] != null)
+                if (entity.Equipment.ContainsKey(2) && entity.Equipment[2] is not null)
                     sb.Append($"\n   [MCC] {Translations.cmd_entityCmd_boots}: {entity.Equipment[2].GetTypeString()} x{entity.Equipment[2].Count}");
             }
 

--- a/MinecraftClient/Commands/Inventory.cs
+++ b/MinecraftClient/Commands/Inventory.cs
@@ -276,7 +276,7 @@ namespace MinecraftClient.Commands
             }
 
             Container? inventory = handler.GetInventory(inventoryId.Value);
-            if (inventory == null)
+            if (inventory is null)
                 return r.SetAndReturn(CmdResult.Status.Fail, string.Format(Translations.cmd_inventory_not_exist, inventoryId));
 
             if (handler.CloseInventory(inventoryId.Value))
@@ -299,7 +299,7 @@ namespace MinecraftClient.Commands
             }
 
             Container? inventory = handler.GetInventory(inventoryId.Value);
-            if (inventory == null)
+            if (inventory is null)
                 return r.SetAndReturn(CmdResult.Status.Fail, string.Format(Translations.cmd_inventory_not_exist, inventoryId));
 
             StringBuilder response = new();
@@ -307,7 +307,7 @@ namespace MinecraftClient.Commands
             response.AppendLine(String.Format(" #{0} - {1}§8", inventoryId, inventory.Title));
 
             string? asciiArt = inventory.Type.GetAsciiArt();
-            if (asciiArt != null && Settings.Config.Main.Advanced.ShowInventoryLayout)
+            if (asciiArt is not null && Settings.Config.Main.Advanced.ShowInventoryLayout)
                 response.AppendLine(asciiArt);
 
             int selectedHotbar = handler.GetCurrentSlot() + 1;
@@ -342,7 +342,7 @@ namespace MinecraftClient.Commands
             }
 
             Container? inventory = handler.GetInventory(inventoryId.Value);
-            if (inventory == null)
+            if (inventory is null)
                 return r.SetAndReturn(CmdResult.Status.Fail, string.Format(Translations.cmd_inventory_not_exist, inventoryId));
 
             string keyName = actionType switch
@@ -373,7 +373,7 @@ namespace MinecraftClient.Commands
             }
 
             Container? inventory = handler.GetInventory(inventoryId.Value);
-            if (inventory == null)
+            if (inventory is null)
                 return r.SetAndReturn(CmdResult.Status.Fail, string.Format(Translations.cmd_inventory_not_exist, inventoryId));
 
             // check item exist

--- a/MinecraftClient/ConsoleIO.cs
+++ b/MinecraftClient/ConsoleIO.cs
@@ -225,7 +225,7 @@ namespace MinecraftClient
                         sugList.Add(new("/"));
 
                         var childs = McClient.dispatcher.GetRoot().Children;
-                        if (childs != null)
+                        if (childs is not null)
                             foreach (var child in childs)
                                 sugList.Add(new(child.Name));
 
@@ -247,7 +247,7 @@ namespace MinecraftClient
                     else
                     {
                         CommandDispatcher<CmdResult>? dispatcher = McClient.dispatcher;
-                        if (dispatcher == null)
+                        if (dispatcher is null)
                             return;
 
                         ParseResults<CmdResult> parse = dispatcher.Parse(command, CmdResult.Empty);

--- a/MinecraftClient/Crypto/AesCfb8Stream.cs
+++ b/MinecraftClient/Crypto/AesCfb8Stream.cs
@@ -89,7 +89,7 @@ namespace MinecraftClient.Crypto
             }
 
             Span<byte> blockOutput = stackalloc byte[blockSize];
-            if (FastAes != null)
+            if (FastAes is not null)
                 FastAes.EncryptEcb(ReadStreamIV, blockOutput);
             else
                 Aes!.EncryptEcb(ReadStreamIV, blockOutput, PaddingMode.None);
@@ -122,7 +122,7 @@ namespace MinecraftClient.Crypto
                 }
 
                 int processEnd = readed + curRead;
-                if (FastAes != null)
+                if (FastAes is not null)
                 {
                     for (int idx = readed; idx < processEnd; idx++)
                     {
@@ -161,7 +161,7 @@ namespace MinecraftClient.Crypto
         {
             Span<byte> blockOutput = stackalloc byte[blockSize];
 
-            if (FastAes != null)
+            if (FastAes is not null)
                 FastAes.EncryptEcb(WriteStreamIV, blockOutput);
             else
                 Aes!.EncryptEcb(WriteStreamIV, blockOutput, PaddingMode.None);
@@ -185,7 +185,7 @@ namespace MinecraftClient.Crypto
             for (int wirtten = 0; wirtten < required; ++wirtten)
             {
                 ReadOnlySpan<byte> blockInput = new(outputBuf, wirtten, blockSize);
-                if (FastAes != null)
+                if (FastAes is not null)
                     FastAes.EncryptEcb(blockInput, blockOutput);
                 else
                     Aes!.EncryptEcb(blockInput, blockOutput, PaddingMode.None);

--- a/MinecraftClient/FileMonitor.cs
+++ b/MinecraftClient/FileMonitor.cs
@@ -59,9 +59,9 @@ namespace MinecraftClient
         /// </summary>
         public void Dispose()
         {
-            if (monitor != null)
+            if (monitor is not null)
                 monitor.Item1.Dispose();
-            if (polling != null)
+            if (polling is not null)
                 polling.Item2.Cancel();
         }
 

--- a/MinecraftClient/Inventory/Container.cs
+++ b/MinecraftClient/Inventory/Container.cs
@@ -50,8 +50,8 @@ namespace MinecraftClient.Inventory
             ID = id;
             Type = type;
             Title = title;
-            Items = new Dictionary<int, Item>();
-            Properties = new Dictionary<int, short>();
+            Items = new();
+            Properties = new();
         }
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace MinecraftClient.Inventory
             Type = type;
             Title = title;
             Items = items;
-            Properties = new Dictionary<int, short>();
+            Properties = new();
         }
 
         /// <summary>
@@ -81,8 +81,8 @@ namespace MinecraftClient.Inventory
             ID = id;
             Title = title;
             Type = ConvertType.ToNew(type);
-            Items = new Dictionary<int, Item>();
-            Properties = new Dictionary<int, short>();
+            Items = new();
+            Properties = new();
         }
 
         /// <summary>
@@ -96,8 +96,8 @@ namespace MinecraftClient.Inventory
             ID = id;
             Type = GetContainerType(typeID);
             Title = title;
-            Items = new Dictionary<int, Item>();
-            Properties = new Dictionary<int, short>();
+            Items = new();
+            Properties = new();
         }
 
         /// <summary>
@@ -109,8 +109,8 @@ namespace MinecraftClient.Inventory
             ID = -1;
             Type = type;
             Title = null;
-            Items = new Dictionary<int, Item>();
-            Properties = new Dictionary<int, short>();
+            Items = new();
+            Properties = new();
         }
 
         /// <summary>
@@ -124,7 +124,7 @@ namespace MinecraftClient.Inventory
             Type = type;
             Title = null;
             Items = items;
-            Properties = new Dictionary<int, short>();
+            Properties = new();
         }
 
         /// <summary>
@@ -172,7 +172,7 @@ namespace MinecraftClient.Inventory
         public int[] SearchItem(ItemType itemType)
         {
             List<int> result = new();
-            if (Items != null)
+            if (Items is not null)
             {
                 foreach (var item in Items)
                 {

--- a/MinecraftClient/Inventory/EnchantmentData.cs
+++ b/MinecraftClient/Inventory/EnchantmentData.cs
@@ -1,6 +1,6 @@
 ﻿namespace MinecraftClient.Inventory
 {
-    public class EnchantmentData
+    public record EnchantmentData
     {
         public Enchantments TopEnchantment { get; set; }
         public Enchantments MiddleEnchantment { get; set; }

--- a/MinecraftClient/Inventory/EnchantmentMapping.cs
+++ b/MinecraftClient/Inventory/EnchantmentMapping.cs
@@ -261,7 +261,7 @@ namespace MinecraftClient.Inventory
         /// </summary>
         public static void SetDynamicEnchantmentIdMap(Dictionary<int, string> idMap)
         {
-            dynamicEnchantmentIdMap = new Dictionary<int, Enchantments>();
+            dynamicEnchantmentIdMap = new();
             foreach (var kvp in idMap)
             {
                 var name = kvp.Value.StartsWith("minecraft:") ? kvp.Value.Substring("minecraft:".Length) : kvp.Value;
@@ -273,7 +273,7 @@ namespace MinecraftClient.Inventory
 
         public static Enchantments GetEnchantmentByRegistryId1206(int id)
         {
-            if (dynamicEnchantmentIdMap != null && dynamicEnchantmentIdMap.TryGetValue(id, out var dynValue))
+            if (dynamicEnchantmentIdMap is not null && dynamicEnchantmentIdMap.TryGetValue(id, out var dynValue))
                 return dynValue;
             if (enchantmentMappings.TryGetValue((short)id, out var value))
                 return value;
@@ -282,10 +282,10 @@ namespace MinecraftClient.Inventory
 
         public static int GetRegistryId1206ByEnchantment(Enchantments enchantment)
         {
-            if (reverseEnchantmentMappings == null)
+            if (reverseEnchantmentMappings is null)
             {
-                reverseEnchantmentMappings = new Dictionary<Enchantments, short>();
-                if (dynamicEnchantmentIdMap != null)
+                reverseEnchantmentMappings = new();
+                if (dynamicEnchantmentIdMap is not null)
                 {
                     foreach (var kvp in dynamicEnchantmentIdMap)
                         reverseEnchantmentMappings[kvp.Value] = (short)kvp.Key;

--- a/MinecraftClient/Inventory/Item.cs
+++ b/MinecraftClient/Inventory/Item.cs
@@ -82,20 +82,20 @@ namespace MinecraftClient.Inventory
         {
             get
             {
-                if (Components != null)
+                if (Components is not null)
                 {
                     var customName = Components.OfType<CustomNameComponent>().FirstOrDefault();
-                    if (customName != null && !string.IsNullOrEmpty(customName.CustomName))
+                    if (customName is not null && !string.IsNullOrEmpty(customName.CustomName))
                         return customName.CustomName;
 
                     var itemName = Components.OfType<ItemNameComponent>().FirstOrDefault();
-                    if (itemName != null && !string.IsNullOrEmpty(itemName.ItemName))
+                    if (itemName is not null && !string.IsNullOrEmpty(itemName.ItemName))
                         return itemName.ItemName;
 
                     return null;
                 }
 
-                if (NBT != null && NBT.ContainsKey("display"))
+                if (NBT is not null && NBT.ContainsKey("display"))
                 {
                     if (NBT["display"] is Dictionary<string, object> displayProperties &&
                         displayProperties.ContainsKey("Name"))
@@ -117,17 +117,17 @@ namespace MinecraftClient.Inventory
         {
             get
             {
-                if (Components != null)
+                if (Components is not null)
                 {
                     var loreComponent = Components.OfType<LoreNameComponent1206>().FirstOrDefault();
-                    if (loreComponent != null && loreComponent.Lines.Count > 0)
+                    if (loreComponent is not null && loreComponent.Lines.Count > 0)
                         return loreComponent.Lines.ToArray();
 
                     return null;
                 }
 
                 List<string> lores = new();
-                if (NBT != null && NBT.ContainsKey("display"))
+                if (NBT is not null && NBT.ContainsKey("display"))
                 {
                     if (NBT["display"] is Dictionary<string, object> displayProperties &&
                         displayProperties.ContainsKey("Lore"))
@@ -151,19 +151,19 @@ namespace MinecraftClient.Inventory
         {
             get
             {
-                if (Components != null)
+                if (Components is not null)
                 {
                     var damageComponent = Components.OfType<DamageComponent>().FirstOrDefault();
-                    if (damageComponent != null)
+                    if (damageComponent is not null)
                         return damageComponent.Damage;
 
                     return 0;
                 }
 
-                if (NBT != null && NBT.ContainsKey("Damage"))
+                if (NBT is not null && NBT.ContainsKey("Damage"))
                 {
                     object damage = NBT["Damage"];
-                    if (damage != null)
+                    if (damage is not null)
                     {
                         return int.Parse(damage.ToString() ?? string.Empty, NumberStyles.Any,
                             CultureInfo.CurrentCulture);
@@ -183,11 +183,11 @@ namespace MinecraftClient.Inventory
         {
             get
             {
-                if (Components == null)
+                if (Components is null)
                     return null;
 
                 var enchComp = Components.OfType<EnchantmentsComponent>().FirstOrDefault();
-                if (enchComp != null && enchComp.Enchantments.Count > 0)
+                if (enchComp is not null && enchComp.Enchantments.Count > 0)
                     return enchComp.Enchantments;
 
                 return null;
@@ -220,7 +220,7 @@ namespace MinecraftClient.Inventory
             try
             {
                 var enchList = EnchantmentList;
-                if (enchList != null)
+                if (enchList is not null)
                 {
                     foreach (var ench in enchList)
                     {
@@ -229,7 +229,7 @@ namespace MinecraftClient.Inventory
                         sb.AppendFormat(" | {0} {1}", name, level);
                     }
                 }
-                else if (NBT != null && (NBT.TryGetValue("Enchantments", out object? enchantments) ||
+                else if (NBT is not null && (NBT.TryGetValue("Enchantments", out object? enchantments) ||
                                          NBT.TryGetValue("StoredEnchantments", out enchantments)))
                 {
                     foreach (Dictionary<string, object> enchantment in (object[])enchantments)
@@ -242,7 +242,7 @@ namespace MinecraftClient.Inventory
                     }
                 }
 
-                if (Lores != null && Lores.Length > 0)
+                if (Lores is not null && Lores.Length > 0)
                 {
                     foreach (var lore in Lores)
                         sb.AppendFormat(" | {0}", lore);

--- a/MinecraftClient/Inventory/ItemMovingHelper.cs
+++ b/MinecraftClient/Inventory/ItemMovingHelper.cs
@@ -7,24 +7,10 @@ namespace MinecraftClient.Inventory
     /// <summary>
     /// Class that contains useful methods to move item around in a container
     /// </summary>
-    public class ItemMovingHelper
+    public class ItemMovingHelper(Container c, McClient mc)
     {
-        private readonly Container c;
-        private readonly McClient mc;
-
-        /// <summary>
-        /// Create a helper that contains useful methods to move item around in container
-        /// </summary>
-        /// <param name="c">Source container to use. All method will use this container for handling first slot parameter</param>
-        /// <param name="mc">McClient handler. Needed for sending WindowAction packet to the server</param>
-        /// <remarks>
-        /// If you are using ChatBot API and cannot have direct access to McClient handler, use <see cref="ChatBot.WindowAction(int, int, WindowActionType)"/> as second parameter
-        /// </remarks>
-        public ItemMovingHelper(Container c, McClient mc)
-        {
-            this.c = c;
-            this.mc = mc;
-        }
+        private readonly Container c = c;
+        private readonly McClient mc = mc;
 
         /// <summary>
         /// Move an item fron source to dest. Source should contain an item and dest slot should be empty
@@ -38,9 +24,9 @@ namespace MinecraftClient.Inventory
             // Condition: source has item and dest has no item
             if (ValidateSlots(source, dest, destContainer) &&
                 HasItem(source) &&
-                ((destContainer != null && !HasItem(dest, destContainer)) || (destContainer == null && !HasItem(dest))))
+                ((destContainer is not null && !HasItem(dest, destContainer)) || (destContainer is null && !HasItem(dest))))
                 return mc.DoWindowAction(c.ID, source, WindowActionType.LeftClick)
-                    && mc.DoWindowAction(destContainer == null ? c.ID : destContainer.ID, dest, WindowActionType.LeftClick);
+                    && mc.DoWindowAction(destContainer is null ? c.ID : destContainer.ID, dest, WindowActionType.LeftClick);
             else return false;
         }
 
@@ -56,9 +42,9 @@ namespace MinecraftClient.Inventory
             // Condition: Both slot1 and slot2 has item
             if (ValidateSlots(slot1, slot2, destContainer) &&
                 HasItem(slot1) &&
-                (destContainer != null && HasItem(slot2, destContainer) || (destContainer == null && HasItem(slot2))))
+                (destContainer is not null && HasItem(slot2, destContainer) || (destContainer is null && HasItem(slot2))))
                 return mc.DoWindowAction(c.ID, slot1, WindowActionType.LeftClick)
-                    && mc.DoWindowAction(destContainer == null ? c.ID : destContainer.ID, slot2, WindowActionType.LeftClick)
+                    && mc.DoWindowAction(destContainer is null ? c.ID : destContainer.ID, slot2, WindowActionType.LeftClick)
                     && mc.DoWindowAction(c.ID, slot1, WindowActionType.LeftClick);
             else return false;
         }
@@ -126,7 +112,7 @@ namespace MinecraftClient.Inventory
         /// <returns>The compare result</returns>
         private bool ValidateSlots(int s1, int s2, Container? s2Container = null)
         {
-            if (s2Container == null)
+            if (s2Container is null)
                 return (s1 != s2 && s1 < c.Type.SlotCount() && s2 < c.Type.SlotCount());
             else
                 return (s1 < c.Type.SlotCount() && s2 < s2Container.Type.SlotCount());
@@ -153,7 +139,7 @@ namespace MinecraftClient.Inventory
         /// <returns>True if they are equal</returns>
         private bool ItemTypeEqual(int slot1, int slot2, Container? s2Container = null)
         {
-            if (s2Container == null)
+            if (s2Container is null)
             {
                 if (HasItem(slot1) && HasItem(slot2))
                     return c.Items[slot1].Type == c.Items[slot2].Type;

--- a/MinecraftClient/Inventory/VillagerInfo.cs
+++ b/MinecraftClient/Inventory/VillagerInfo.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Properties of a villager
     /// </summary>
-    public class VillagerInfo
+    public record VillagerInfo
     {
         public int Level { get; set; }
         public int Experience { get; set; }

--- a/MinecraftClient/Inventory/VillagerTrade.cs
+++ b/MinecraftClient/Inventory/VillagerTrade.cs
@@ -3,31 +3,15 @@
     /// <summary>
     /// Represents a trade of a villager
     /// </summary>
-    public class VillagerTrade
-    {
-        public Item InputItem1;
-        public Item OutputItem;
-        public Item? InputItem2;
-        public bool TradeDisabled;
-        public int NumberOfTradeUses;
-        public int MaximumNumberOfTradeUses;
-        public int Xp;
-        public int SpecialPrice;
-        public float PriceMultiplier;
-        public int Demand;
-
-        public VillagerTrade(Item inputItem1, Item outputItem, Item? inputItem2, bool tradeDisabled, int numberOfTradeUses, int maximumNumberOfTradeUses, int xp, int specialPrice, float priceMultiplier, int demand)
-        {
-            InputItem1 = inputItem1;
-            OutputItem = outputItem;
-            InputItem2 = inputItem2;
-            TradeDisabled = tradeDisabled;
-            NumberOfTradeUses = numberOfTradeUses;
-            MaximumNumberOfTradeUses = maximumNumberOfTradeUses;
-            Xp = xp;
-            SpecialPrice = specialPrice;
-            PriceMultiplier = priceMultiplier;
-            Demand = demand;
-        }
-    }
+    public record VillagerTrade(
+        Item InputItem1,
+        Item OutputItem,
+        Item? InputItem2,
+        bool TradeDisabled,
+        int NumberOfTradeUses,
+        int MaximumNumberOfTradeUses,
+        int Xp,
+        int SpecialPrice,
+        float PriceMultiplier,
+        int Demand);
 }

--- a/MinecraftClient/Logger/FileLogLogger.cs
+++ b/MinecraftClient/Logger/FileLogLogger.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Threading;
 using MinecraftClient.Scripting;
 
 namespace MinecraftClient.Logger
@@ -8,7 +9,7 @@ namespace MinecraftClient.Logger
     {
         private readonly string logFile;
         private readonly bool prependTimestamp;
-        private readonly object logFileLock = new();
+        private readonly Lock logFileLock = new();
 
         public FileLogLogger(string file, bool prependTimestamp = false)
         {

--- a/MinecraftClient/Logger/FilteredLogger.cs
+++ b/MinecraftClient/Logger/FilteredLogger.cs
@@ -31,7 +31,7 @@ namespace MinecraftClient.Logger
                         regexToUse = new(debug);
                     break;
             }
-            if (regexToUse != null)
+            if (regexToUse is not null)
             {
                 // IsMatch and white/blacklist result can be represented using XOR
                 // e.g.  matched(true) ^ blacklist(true) => shouldn't log(false)

--- a/MinecraftClient/Mapping/BlockPalettes/BlockPaletteGenerator.cs
+++ b/MinecraftClient/Mapping/BlockPalettes/BlockPaletteGenerator.cs
@@ -137,7 +137,7 @@ namespace MinecraftClient.Mapping.BlockPalettes
 
             File.WriteAllLines(outputPalettePath, outFile);
 
-            if (outputEnum != null)
+            if (outputEnum is not null)
             {
                 outFile = new List<string>();
                 outFile.AddRange(new[] {

--- a/MinecraftClient/Mapping/Dimension.cs
+++ b/MinecraftClient/Mapping/Dimension.cs
@@ -129,7 +129,7 @@ namespace MinecraftClient.Mapping
         {
             Name = name ?? throw new ArgumentNullException(nameof(name));
 
-            if (nbt == null)
+            if (nbt is null)
                 throw new ArgumentNullException(nameof(nbt));
 
             if (nbt.ContainsKey("piglin_safe"))

--- a/MinecraftClient/Mapping/DirectionExtensions.cs
+++ b/MinecraftClient/Mapping/DirectionExtensions.cs
@@ -1,63 +1,42 @@
 ﻿using System;
 
-namespace MinecraftClient.Mapping
+namespace MinecraftClient.Mapping;
+
+public static class DirectionExtensions
 {
-    public static class DirectionExtensions
+    public static Direction GetOpposite(this Direction direction) => direction switch
     {
-        public static Direction GetOpposite(this Direction direction)
-        {
-            switch (direction)
-            {
-                case Direction.SouthEast:
-                    return Direction.NorthEast;
-                case Direction.SouthWest:
-                    return Direction.NorthWest;
+        Direction.SouthEast => Direction.NorthEast,
+        Direction.SouthWest => Direction.NorthWest,
+        Direction.NorthEast => Direction.SouthEast,
+        Direction.NorthWest => Direction.SouthWest,
+        Direction.West => Direction.East,
+        Direction.East => Direction.West,
+        Direction.North => Direction.South,
+        Direction.South => Direction.North,
+        Direction.Down => Direction.Up,
+        Direction.Up => Direction.Down,
+        _ => Direction.Up,
+    };
 
-                case Direction.NorthEast:
-                    return Direction.SouthEast;
-                case Direction.NorthWest:
-                    return Direction.SouthWest;
+    public static Direction[] HORIZONTAL =
+    [
+        Direction.South,
+        Direction.West,
+        Direction.North,
+        Direction.East,
+    ];
 
-                case Direction.West:
-                    return Direction.East;
-                case Direction.East:
-                    return Direction.West;
+    public static Direction FromRotation(double rotation)
+    {
+        double floor = Math.Floor((rotation / 90.0) + 0.5);
+        int value = (int)floor & 3;
 
-                case Direction.North:
-                    return Direction.South;
-                case Direction.South:
-                    return Direction.North;
+        return FromHorizontal(value);
+    }
 
-                case Direction.Down:
-                    return Direction.Up;
-                case Direction.Up:
-                    return Direction.Down;
-                default:
-                    return Direction.Up;
-
-            }
-        }
-        
-
-        public static Direction[] HORIZONTAL =
-        {
-            Direction.South,
-            Direction.West,
-            Direction.North,
-            Direction.East
-        };
-
-        public static Direction FromRotation(double rotation)
-        {
-            double floor = Math.Floor((rotation / 90.0) + 0.5);
-            int value = (int)floor & 3;
-
-            return FromHorizontal(value);
-        }
-
-        public static Direction FromHorizontal(int value)
-        {
-            return HORIZONTAL[Math.Abs(value % HORIZONTAL.Length)];
-        }
+    public static Direction FromHorizontal(int value)
+    {
+        return HORIZONTAL[Math.Abs(value % HORIZONTAL.Length)];
     }
 }

--- a/MinecraftClient/Mapping/EntityPalettes/EntityPalette.cs
+++ b/MinecraftClient/Mapping/EntityPalettes/EntityPalette.cs
@@ -29,9 +29,9 @@ namespace MinecraftClient.Mapping.EntityPalettes
             Dictionary<int, EntityType> entityTypes = GetDict();
             Dictionary<int, EntityType>? entityTypesNonLiving = GetDictNonLiving();
 
-            if (entityTypesNonLiving != null && !living)
+            if (entityTypesNonLiving is not null && !living)
             {
-                //Pre-1.14 non-living entities have a different set of IDs (entityTypesNonLiving != null)
+                //Pre-1.14 non-living entities have a different set of IDs (entityTypesNonLiving is not null)
                 if (entityTypesNonLiving.ContainsKey(id))
                     return entityTypesNonLiving[id];
             }

--- a/MinecraftClient/Mapping/EntityPalettes/EntityPalette112.cs
+++ b/MinecraftClient/Mapping/EntityPalettes/EntityPalette112.cs
@@ -9,7 +9,7 @@ namespace MinecraftClient.Mapping.EntityPalettes
     /// </summary>
     public class EntityPalette112 : EntityPalette
     {
-        private static Dictionary<int, EntityType> mappingsObjects = new Dictionary<int, EntityType>()
+        private static Dictionary<int, EntityType> mappingsObjects = new()
         {
             // https://wiki.vg/Entity_metadata#Objects
             { 1, EntityType.Boat },
@@ -41,7 +41,7 @@ namespace MinecraftClient.Mapping.EntityPalettes
             { 93, EntityType.DragonFireball },
         };
 
-        private static Dictionary<int, EntityType> mappingsMobs = new Dictionary<int, EntityType>()
+        private static Dictionary<int, EntityType> mappingsMobs = new()
         {
             { 1, EntityType.Item },
             { 2, EntityType.ExperienceOrb },

--- a/MinecraftClient/Mapping/EntityPalettes/EntityPalette113.cs
+++ b/MinecraftClient/Mapping/EntityPalettes/EntityPalette113.cs
@@ -9,7 +9,7 @@ namespace MinecraftClient.Mapping.EntityPalettes
     /// </summary>
     public class EntityPalette113 : EntityPalette
     {
-        private static Dictionary<int, EntityType> mappingsObjects = new Dictionary<int, EntityType>()
+        private static Dictionary<int, EntityType> mappingsObjects = new()
         {
             // https://wiki.vg/Entity_metadata#Objects
             { 1, EntityType.Boat },
@@ -42,7 +42,7 @@ namespace MinecraftClient.Mapping.EntityPalettes
             { 94, EntityType.Trident },
         };
 
-        private static Dictionary<int, EntityType> mappingsMobs = new Dictionary<int, EntityType>()
+        private static Dictionary<int, EntityType> mappingsMobs = new()
         {
             // https://wiki.vg/Entity_metadata#Mobs
             { 0, EntityType.AreaEffectCloud },

--- a/MinecraftClient/Mapping/EntityPalettes/EntityPalette18.cs
+++ b/MinecraftClient/Mapping/EntityPalettes/EntityPalette18.cs
@@ -10,7 +10,7 @@ namespace MinecraftClient.Mapping.EntityPalettes
     /// </summary>
     public class EntityPalette18 : EntityPalette
     {
-        private static Dictionary<int, EntityType> mappingsObjects = new Dictionary<int, EntityType>()
+        private static Dictionary<int, EntityType> mappingsObjects = new()
         {
             // https://wiki.vg/Entity_metadata#Objects
             { 1, EntityType.Boat },
@@ -39,7 +39,7 @@ namespace MinecraftClient.Mapping.EntityPalettes
             { 93, EntityType.DragonFireball },
         };
 
-        private static Dictionary<int, EntityType> mappingsMobs = new Dictionary<int, EntityType>() {
+        private static Dictionary<int, EntityType> mappingsMobs = new() {
             { 1, EntityType.Item },
             { 2, EntityType.ExperienceOrb },
             { 8, EntityType.LeashKnot },

--- a/MinecraftClient/Mapping/Location.cs
+++ b/MinecraftClient/Mapping/Location.cs
@@ -108,7 +108,7 @@ namespace MinecraftClient.Mapping
         public static Location Parse(string x, string y, string z)
         {
             Location.TryParse(x, y, z, out Location? res);
-            if (res == null)
+            if (res is null)
                 throw new FormatException();
             else
                 return (Location)res;
@@ -116,7 +116,7 @@ namespace MinecraftClient.Mapping
 
         public static bool TryParse(string x, string y, string z, out Location? location)
         {
-            string[] coord_str = new string[] { x.Trim(), y.Trim(), z.Trim() };
+            string[] coord_str = [x.Trim(), y.Trim(), z.Trim()];
             double[] coord_res = new double[3];
 
             for (int i = 0; i < 3; ++i)
@@ -144,7 +144,7 @@ namespace MinecraftClient.Mapping
         public static Location Parse(Location current, string x, string y, string z)
         {
             Location.TryParse(current, x, y, z, out Location? res);
-            if (res == null)
+            if (res is null)
                 throw new FormatException();
             else
                 return (Location)res;
@@ -152,9 +152,9 @@ namespace MinecraftClient.Mapping
 
         public static bool TryParse(Location current, string x, string y, string z, out Location? location)
         {
-            string[] coord_str = new string[] { x.Trim(), y.Trim(), z.Trim() };
+            string[] coord_str = [x.Trim(), y.Trim(), z.Trim()];
             double[] coord_res = new double[3];
-            double[] coord_cur = new double[] { current.X, current.Y, current.Z };
+            double[] coord_cur = [current.X, current.Y, current.Z];
 
             for (int i = 0; i < 3; ++i)
             {
@@ -308,7 +308,7 @@ namespace MinecraftClient.Mapping
         /// <returns>TRUE if the locations are equals</returns>
         public override bool Equals(object? obj)
         {
-            if (obj == null)
+            if (obj is null)
                 return false;
             if (obj is Location location)
             {

--- a/MinecraftClient/Mapping/MapIcon.cs
+++ b/MinecraftClient/Mapping/MapIcon.cs
@@ -1,11 +1,11 @@
 ﻿namespace MinecraftClient.Mapping
 {
-    public class MapIcon
+    public record MapIcon
     {
-        public MapIconType Type { set; get; }
-        public byte X { set; get; }
-        public byte Z { set; get; }
-        public byte Direction { set; get; }
-        public string? DisplayName { set; get; } = null;
+        public MapIconType Type { get; set; }
+        public byte X { get; set; }
+        public byte Z { get; set; }
+        public byte Direction { get; set; }
+        public string? DisplayName { get; set; } = null;
     }
 }

--- a/MinecraftClient/Mapping/Movement.cs
+++ b/MinecraftClient/Mapping/Movement.cs
@@ -247,7 +247,7 @@ namespace MinecraftClient.Mapping
             }
 
             // Goal could not be reached. Set the path to the closest location if close enough
-            if (current != null && openSet.MinHScoreNode != null &&
+            if (current is not null && openSet.MinHScoreNode is not null &&
                 (maxOffset == int.MaxValue || openSet.MinHScoreNode.HScore <= maxOffset))
                 return ReconstructPath(cameFrom, openSet.MinHScoreNode.Location, start, goal);
 
@@ -306,27 +306,9 @@ namespace MinecraftClient.Mapping
             /// <summary>
             /// Represents a location and its attributes
             /// </summary>
-            public class Node
+            public record Node(int GScore, int HScore, Location Location)
             {
-                // Distance to start
-                public int GScore;
-
-                // Distance to Goal
-                public int HScore;
-
-                public int FScore
-                {
-                    get { return HScore + GScore; }
-                }
-
-                public Location Location;
-
-                public Node(int gScore, int hScore, Location loc)
-                {
-                    this.GScore = gScore;
-                    this.HScore = hScore;
-                    Location = loc;
-                }
+                public int FScore => HScore + GScore;
             }
 
             // List which contains all nodes in form of a Binary Heap
@@ -338,8 +320,8 @@ namespace MinecraftClient.Mapping
 
             public BinaryHeap()
             {
-                heapList = new List<Node>();
-                locationList = new HashSet<Location>();
+                heapList = new();
+                locationList = new();
                 MinHScoreNode = null;
             }
 
@@ -362,7 +344,7 @@ namespace MinecraftClient.Mapping
                 locationList.Add(loc);
 
                 // Save node with the smallest H-Score => Distance to goal
-                if (MinHScoreNode == null || newNode.HScore < MinHScoreNode.HScore)
+                if (MinHScoreNode is null || newNode.HScore < MinHScoreNode.HScore)
                     MinHScoreNode = newNode;
 
                 if (i == 0)
@@ -491,7 +473,7 @@ namespace MinecraftClient.Mapping
         public static bool IsOnGround(World world, Location location)
         {
             ChunkColumn? chunkColumn = world.GetChunkColumn(location);
-            if (chunkColumn == null || chunkColumn.FullyLoaded == false)
+            if (chunkColumn is null || chunkColumn.FullyLoaded == false)
                 return true; // avoid moving downward in a not loaded chunk
 
             Location down = Move(location, Direction.Down);
@@ -721,11 +703,11 @@ namespace MinecraftClient.Mapping
         public static bool CheckChunkLoading(World world, Location start, Location dest)
         {
             var chunkColumn = world.GetChunkColumn(dest);
-            if (chunkColumn == null || chunkColumn.FullyLoaded == false)
+            if (chunkColumn is null || chunkColumn.FullyLoaded == false)
                 return false;
 
             chunkColumn = world.GetChunkColumn(start);
-            if (chunkColumn == null || chunkColumn.FullyLoaded == false)
+            if (chunkColumn is null || chunkColumn.FullyLoaded == false)
                 return false;
 
             return true;

--- a/MinecraftClient/Mapping/World.cs
+++ b/MinecraftClient/Mapping/World.cs
@@ -55,7 +55,7 @@ namespace MinecraftClient.Mapping
             set
             {
                 Tuple<int, int> chunkCoord = new(chunkX, chunkZ);
-                if (value == null)
+                if (value is null)
                     chunks.TryRemove(chunkCoord, out _);
                 else
                     chunks.AddOrUpdate(chunkCoord, value, (_, _) => value);
@@ -317,7 +317,7 @@ namespace MinecraftClient.Mapping
 	public static void SetDimension(string name)
 	{
 	    // Try to get the dimension using the name as is
-	    if (dimensionList.TryGetValue(name, out Dimension dimension))
+	    if (dimensionList.TryGetValue(name, out Dimension? dimension))
 	    {
 		curDimension = dimension;
 		return; // Dimension found
@@ -385,10 +385,10 @@ namespace MinecraftClient.Mapping
         public Block GetBlock(Location location)
         {
             ChunkColumn? column = GetChunkColumn(location);
-            if (column != null)
+            if (column is not null)
             {
                 Chunk? chunk = column.GetChunk(location);
-                if (chunk != null)
+                if (chunk is not null)
                     return chunk.GetBlock(location);
             }
             return Block.Air;
@@ -437,10 +437,10 @@ namespace MinecraftClient.Mapping
         public void SetBlock(Location location, Block block)
         {
             ChunkColumn? column = this[location.ChunkX, location.ChunkZ];
-            if (column != null && column.ColumnSize >= location.ChunkY)
+            if (column is not null && column.ColumnSize >= location.ChunkY)
             {
                 Chunk? chunk = column.GetChunk(location);
-                if (chunk == null)
+                if (chunk is null)
                     column[location.ChunkY] = chunk = new Chunk();
                 chunk[location.ChunkBlockX, location.ChunkBlockY, location.ChunkBlockZ] = block;
             }

--- a/MinecraftClient/McClient.cs
+++ b/MinecraftClient/McClient.cs
@@ -43,7 +43,7 @@ namespace MinecraftClient
         private static DateTime nextMessageSendTime = DateTime.MinValue;
 
         private readonly Queue<Action> threadTasks = new();
-        private readonly object threadTasksLock = new();
+        private readonly Lock threadTasksLock = new();
 
         private readonly List<ChatBot> bots = new();
         private static readonly List<ChatBot> botsOnHold = new();
@@ -58,17 +58,15 @@ namespace MinecraftClient
         private bool inventoryHandlingRequested = false;
         private bool entityHandlingEnabled;
 
-        private readonly object locationLock = new();
+        private readonly Lock locationLock = new();
         private bool locationReceived = false;
         private readonly World world = new();
-        private Queue<Location>? steps;
         private Queue<Location>? path;
         private Location location;
         private float? _yaw; // Used for calculation ONLY!!! Doesn't reflect the client yaw
         private float? _pitch; // Used for calculation ONLY!!! Doesn't reflect the client pitch
         private float playerYaw;
         private float playerPitch;
-        private double motionY;
         private readonly PlayerPhysics playerPhysics = new();
         private readonly MovementInput physicsInput = new();
         private bool physicsInitialized = false;
@@ -86,7 +84,7 @@ namespace MinecraftClient
         private readonly string sessionid;
         private readonly PlayerKeyPair? playerKeyPair;
         private DateTime lastKeepAlive;
-        private readonly object lastKeepAliveLock = new();
+        private readonly Lock lastKeepAliveLock = new();
         private int respawnTicks = 0;
         private int gamemode = 0;
         private bool isSupportPreviewsChat;
@@ -94,7 +92,7 @@ namespace MinecraftClient
 
         private int playerEntityID;
 
-        private object DigLock = new();
+        private readonly Lock DigLock = new();
         private Tuple<Location, Direction>? LastDigPosition;
         private int RemainingDiggingTime = 0;
 
@@ -156,8 +154,8 @@ namespace MinecraftClient
         public void SetCookie(string key, byte[] data) => Cookies[key] = data;
         public void DeleteCookie(string key) => Cookies.Remove(key, out var data);
 
-        TcpClient client;
-        IMinecraftCom handler;
+        TcpClient client = null!;
+        IMinecraftCom handler = null!;
         SessionToken _sessionToken;
         CancellationTokenSource? cmdprompt = null;
         Tuple<Thread, CancellationTokenSource>? timeoutdetector = null;
@@ -210,10 +208,10 @@ namespace MinecraftClient
             {
                 scope.SetTag("Protocol Version", protocolversion.ToString());
                 scope.SetTag("Minecraft Version", ProtocolHandler.ProtocolVersion2MCVer(protocolversion));
-                scope.SetTag("MCC Build", Program.BuildInfo == null ? "Debug" : Program.BuildInfo);
+                scope.SetTag("MCC Build", Program.BuildInfo is null ? "Debug" : Program.BuildInfo);
                     
-                if (forgeInfo != null)
-                    scope.SetTag("Forge Version", forgeInfo?.Version.ToString());
+                if (forgeInfo is not null)
+                    scope.SetTag("Forge Version", forgeInfo.Version.ToString());
 
                 scope.Contexts["Server Information"] = new
                 {
@@ -288,7 +286,7 @@ namespace MinecraftClient
             return;
 
             Retry:
-            if (timeoutdetector != null)
+            if (timeoutdetector is not null)
             {
                 timeoutdetector.Item2.Cancel();
                 timeoutdetector = null;
@@ -377,7 +375,7 @@ namespace MinecraftClient
                 Log.Error($"Transfer to {newHost}:{newPort} failed: {ex.Message}");
 
                 // Handle reconnection attempts
-                if (timeoutdetector != null)
+                if (timeoutdetector is not null)
                 {
                     timeoutdetector.Item2.Cancel();
                     timeoutdetector = null;
@@ -514,8 +512,8 @@ namespace MinecraftClient
                     UpdatePathfindingInput();
 
                     // Sync yaw/pitch if explicitly set (by commands/bots)
-                    if (_yaw != null) playerPhysics.Yaw = _yaw.Value;
-                    if (_pitch != null) playerPhysics.Pitch = _pitch.Value;
+                    if (_yaw is not null) playerPhysics.Yaw = _yaw.Value;
+                    if (_pitch is not null) playerPhysics.Pitch = _pitch.Value;
 
                     // Update environment flags (water, lava, climbable)
                     playerPhysics.UpdateEnvironment(world);
@@ -563,7 +561,7 @@ namespace MinecraftClient
             {
                 if (RemainingDiggingTime > 0)
                 {
-                    if (--RemainingDiggingTime == 0 && LastDigPosition != null)
+                    if (--RemainingDiggingTime == 0 && LastDigPosition is not null)
                     {
                         handler.SendPlayerDigging(2, LastDigPosition.Item1, LastDigPosition.Item2, sequenceId++);
                         Log.Info(string.Format(Translations.cmd_dig_end, LastDigPosition.Item1));
@@ -627,25 +625,25 @@ namespace MinecraftClient
             botsOnHold.Clear();
             botsOnHold.AddRange(bots);
 
-            if (handler != null)
+            if (handler is not null)
             {
                 handler.Disconnect();
                 handler.Dispose();
             }
 
-            if (cmdprompt != null)
+            if (cmdprompt is not null)
             {
                 cmdprompt.Cancel();
                 cmdprompt = null;
             }
 
-            if (timeoutdetector != null)
+            if (timeoutdetector is not null)
             {
                 timeoutdetector.Item2.Cancel();
                 timeoutdetector = null;
             }
 
-            if (client != null)
+            if (client is not null)
                 client.Close();
         }
 
@@ -660,9 +658,9 @@ namespace MinecraftClient
 
             world.Clear();
 
-            if (timeoutdetector != null)
+            if (timeoutdetector is not null)
             {
-                if (timeoutdetector != null && Thread.CurrentThread != timeoutdetector.Item1)
+                if (timeoutdetector is not null && Thread.CurrentThread != timeoutdetector.Item1)
                     timeoutdetector.Item2.Cancel();
                 timeoutdetector = null;
             }
@@ -728,7 +726,7 @@ namespace MinecraftClient
         private void ConsoleReaderOnMessageReceived(object? sender, string e)
         {
 
-            if (client.Client == null)
+            if (client.Client is null)
                 return;
 
             if (client.Client.Connected)
@@ -980,7 +978,7 @@ namespace MinecraftClient
             get
             {
                 int callingThreadId = Environment.CurrentManagedThreadId;
-                if (handler != null)
+                if (handler is not null)
                 {
                     return handler.GetNetMainThreadId() != callingThreadId;
                 }
@@ -1010,9 +1008,9 @@ namespace MinecraftClient
             b.SetHandler(this);
             bots.Add(b);
             if (init)
-                DispatchBotEvent(bot => bot.Initialize(), new ChatBot[] { b });
-            if (handler != null)
-                DispatchBotEvent(bot => bot.AfterGameJoined(), new ChatBot[] { b });
+                DispatchBotEvent(bot => bot.Initialize(), [b]);
+            if (handler is not null)
+                DispatchBotEvent(bot => bot.AfterGameJoined(), [b]);
         }
 
         /// <summary>
@@ -1205,7 +1203,7 @@ namespace MinecraftClient
         /// <returns></returns>
         public static char[] GetDisallowedChatCharacters()
         {
-            return new char[] { (char)167, (char)127 }; // Minecraft color code and ASCII code DEL
+            return [(char)167, (char)127]; // Minecraft color code and ASCII code DEL
         }
 
         /// <summary>
@@ -1353,7 +1351,7 @@ namespace MinecraftClient
                 {
                     pathTarget = null;
                     path = Movement.CalculatePath(world, location, goal, allowUnsafe, maxOffset, minOffset, timeout ?? TimeSpan.FromSeconds(5));
-                    return path != null;
+                    return path is not null;
                 }
             }
         }
@@ -1591,7 +1589,7 @@ namespace MinecraftClient
             // Update our inventory base on action type
             Container inventory = GetInventory(windowId)!;
             Container playerInventory = GetInventory(0)!;
-            if (inventory != null)
+            if (inventory is not null)
             {
                 switch (action)
                 {
@@ -1738,7 +1736,7 @@ namespace MinecraftClient
                     case WindowActionType.ShiftClick:
                     case WindowActionType.ShiftRightClick:
                         if (slotId == 0) break;
-                        if (item != null)
+                        if (item is not null)
                         {
                             /* Target slot have item */
 
@@ -1758,7 +1756,7 @@ namespace MinecraftClient
                                         upper2backpack = true;
                                         lowerStartSlot = 9;
                                     }
-                                    else if (item != null && false /* Check if wearable */)
+                                    else if (item is not null && false /* Check if wearable */)
                                     {
                                         lower2upper = true;
                                         // upperStartSlot = ?;
@@ -1894,7 +1892,7 @@ namespace MinecraftClient
                                         upper2backpack = true;
                                         lowerStartSlot = 1;
                                     }
-                                    else if (item != null && item.Count == 1 && (item.Type == ItemType.NetheriteIngot ||
+                                    else if (item is not null && item.Count == 1 && (item.Type == ItemType.NetheriteIngot ||
                                         item.Type == ItemType.Emerald || item.Type == ItemType.Diamond || item.Type == ItemType.GoldIngot ||
                                         item.Type == ItemType.IronIngot) && !inventory.Items.ContainsKey(0))
                                     {
@@ -1927,7 +1925,7 @@ namespace MinecraftClient
                                         upper2backpack = true;
                                         lowerStartSlot = 3;
                                     }
-                                    else if (item != null && false /* Check if it can be burned */)
+                                    else if (item is not null && false /* Check if it can be burned */)
                                     {
                                         lower2upper = true;
                                         upperStartSlot = 0;
@@ -1954,7 +1952,7 @@ namespace MinecraftClient
                                         upper2backpack = true;
                                         lowerStartSlot = 5;
                                     }
-                                    else if (item != null && item.Type == ItemType.BlazePowder)
+                                    else if (item is not null && item.Type == ItemType.BlazePowder)
                                     {
                                         lower2upper = true;
                                         if (!inventory.Items.ContainsKey(4) || inventory.Items[4].Count < 64)
@@ -1962,12 +1960,12 @@ namespace MinecraftClient
                                         else
                                             upperStartSlot = upperEndSlot = 3;
                                     }
-                                    else if (item != null && false /* Check if it can be used for alchemy */)
+                                    else if (item is not null && false /* Check if it can be used for alchemy */)
                                     {
                                         lower2upper = true;
                                         upperStartSlot = upperEndSlot = 3;
                                     }
-                                    else if (item != null && (item.Type == ItemType.Potion || item.Type == ItemType.GlassBottle))
+                                    else if (item is not null && (item.Type == ItemType.Potion || item.Type == ItemType.GlassBottle))
                                     {
                                         lower2upper = true;
                                         upperStartSlot = 0;
@@ -2009,7 +2007,7 @@ namespace MinecraftClient
                                         upper2backpack = true;
                                         lowerStartSlot = 5;
                                     }
-                                    else if (item != null && item.Type == ItemType.LapisLazuli)
+                                    else if (item is not null && item.Type == ItemType.LapisLazuli)
                                     {
                                         lower2upper = true;
                                         upperStartSlot = upperEndSlot = 1;
@@ -2029,7 +2027,7 @@ namespace MinecraftClient
                                         upper2backpack = true;
                                         lowerStartSlot = 3;
                                     }
-                                    else if (item != null && false /* Check */)
+                                    else if (item is not null && false /* Check */)
                                     {
                                         lower2upper = true;
                                         upperStartSlot = 0;
@@ -2066,7 +2064,7 @@ namespace MinecraftClient
                                         upper2backpack = true;
                                         lowerStartSlot = 4;
                                     }
-                                    else if (item != null && false /* Check for availability for staining */)
+                                    else if (item is not null && false /* Check for availability for staining */)
                                     {
                                         lower2upper = true;
                                         // upperStartSlot = ?;
@@ -2095,7 +2093,7 @@ namespace MinecraftClient
                                         upper2backpack = true;
                                         lowerStartSlot = 3;
                                     }
-                                    else if (item != null && false /* Check if it is available for trading */)
+                                    else if (item is not null && false /* Check if it is available for trading */)
                                     {
                                         lower2upper = true;
                                         upperStartSlot = 0;
@@ -2124,12 +2122,12 @@ namespace MinecraftClient
                                         upper2backpack = true;
                                         lowerStartSlot = 3;
                                     }
-                                    else if (item != null && item.Type == ItemType.FilledMap)
+                                    else if (item is not null && item.Type == ItemType.FilledMap)
                                     {
                                         lower2upper = true;
                                         upperStartSlot = upperEndSlot = 0;
                                     }
-                                    else if (item != null && item.Type == ItemType.Map)
+                                    else if (item is not null && item.Type == ItemType.Map)
                                     {
                                         lower2upper = true;
                                         upperStartSlot = upperEndSlot = 1;
@@ -2157,7 +2155,7 @@ namespace MinecraftClient
                                         upper2backpack = true;
                                         lowerStartSlot = 2;
                                     }
-                                    else if (item != null && false /* Check if it is available for stone cutteing */)
+                                    else if (item is not null && false /* Check if it is available for stone cutteing */)
                                     {
                                         lower2upper = true;
                                         upperStartSlot = 0;
@@ -2381,23 +2379,18 @@ namespace MinecraftClient
 
             if (entities.ContainsKey(entityID))
             {
-                switch (type)
+                return type switch
                 {
-                    case InteractType.Interact:
-                        return handler.SendInteractEntity(entityID, (int)type, (int)hand);
-                    
-                    case InteractType.InteractAt:
-                        return handler.SendInteractEntity(
-                            EntityID: entityID, 
-                            type: (int)type, 
-                            X: (float)entities[entityID].Location.X, 
-                            Y: (float)entities[entityID].Location.Y, 
-                            Z: (float)entities[entityID].Location.Z, 
-                            hand: (int)hand);
-                    
-                    default:
-                        return handler.SendInteractEntity(entityID, (int)type);
-                }
+                    InteractType.Interact => handler.SendInteractEntity(entityID, (int)type, (int)hand),
+                    InteractType.InteractAt => handler.SendInteractEntity(
+                        EntityID: entityID,
+                        type: (int)type,
+                        X: (float)entities[entityID].Location.X,
+                        Y: (float)entities[entityID].Location.Y,
+                        Z: (float)entities[entityID].Location.Z,
+                        hand: (int)hand),
+                    _ => handler.SendInteractEntity(entityID, (int)type),
+                };
             }
             
             return false;
@@ -2442,7 +2435,7 @@ namespace MinecraftClient
 
             lock (DigLock)
             {
-                if (RemainingDiggingTime > 0 && LastDigPosition != null)
+                if (RemainingDiggingTime > 0 && LastDigPosition is not null)
                 {
                     handler.SendPlayerDigging(1, LastDigPosition.Item1, LastDigPosition.Item2, sequenceId++);
                     Log.Info(string.Format(Translations.cmd_dig_cancel, LastDigPosition.Item1));
@@ -2587,7 +2580,7 @@ namespace MinecraftClient
         {
             ChatBot[] selectedBots;
 
-            if (botList != null)
+            if (botList is not null)
             {
                 selectedBots = botList.ToArray();
             }
@@ -2639,7 +2632,7 @@ namespace MinecraftClient
         /// </summary>
         public void OnGameJoined(bool isOnlineMode)
         {
-            if (protocolversion < Protocol18Handler.MC_1_19_3_Version || playerKeyPair == null || !isOnlineMode)
+            if (protocolversion < Protocol18Handler.MC_1_19_3_Version || playerKeyPair is null || !isOnlineMode)
                 SetCanSendMessage(true);
             else
                 SetCanSendMessage(false);
@@ -2659,7 +2652,7 @@ namespace MinecraftClient
                     (byte)Config.MCSettings.MainHand);
 
             if (protocolversion >= Protocol18Handler.MC_1_19_3_Version
-                && playerKeyPair != null && isOnlineMode)
+                && playerKeyPair is not null && isOnlineMode)
                 handler.SendPlayerSession(playerKeyPair);
 
             if (inventoryHandlingRequested)
@@ -2709,10 +2702,10 @@ namespace MinecraftClient
             physicsInput.Reset();
 
             // Still heading toward a target (even if path queue is empty)
-            if (pathTarget != null && ReachedWaypoint(pathTarget.Value))
+            if (pathTarget is not null && ReachedWaypoint(pathTarget.Value))
             {
                 // Arrived at current waypoint — advance to next, or finish
-                if (path != null && path.Count > 0)
+                if (path is not null && path.Count > 0)
                 {
                     pathTarget = path.Dequeue();
                     if (Config.Main.Advanced.MoveHeadWhileWalking)
@@ -2726,14 +2719,14 @@ namespace MinecraftClient
             }
 
             // Need a first target from a fresh path
-            if (pathTarget == null && path != null && path.Count > 0)
+            if (pathTarget is null && path is not null && path.Count > 0)
             {
                 pathTarget = path.Dequeue();
                 if (Config.Main.Advanced.MoveHeadWhileWalking)
                     UpdateLocation(location, pathTarget.Value + new Location(0, 1, 0));
             }
 
-            if (pathTarget != null)
+            if (pathTarget is not null)
             {
                 SetInputToward(pathTarget.Value);
             }
@@ -2787,7 +2780,7 @@ namespace MinecraftClient
         /// <returns>true if a movement is currently handled</returns>
         public bool ClientIsMoving()
         {
-            return terrainAndMovementsEnabled && locationReceived && ((steps != null && steps.Count > 0) || (path != null && path.Count > 0));
+            return terrainAndMovementsEnabled && locationReceived && path is not null && path.Count > 0;
         }
 
         /// <summary>
@@ -2796,7 +2789,7 @@ namespace MinecraftClient
         /// <returns>Current goal of movement. Location.Zero if not set.</returns>
         public Location GetCurrentMovementGoal()
         {
-            return (ClientIsMoving() || path == null) ? Location.Zero : path.Last();
+            return (ClientIsMoving() || path is null) ? Location.Zero : path.Last();
         }
 
         /// <summary>
@@ -2959,7 +2952,7 @@ namespace MinecraftClient
                 {
                     if ((bool)message.isSignatureLegal!)
                     {
-                        if (Config.Signature.ShowModifiedChat && message.unsignedContent != null)
+                        if (Config.Signature.ShowModifiedChat && message.unsignedContent is not null)
                         {
                             if (Config.Signature.MarkModifiedMsg)
                                 color = "§6▌§r"; // Background Yellow
@@ -3181,7 +3174,7 @@ namespace MinecraftClient
                 inventoryID = 0; // Prevent key not found for some bots relied to this event
                 if (inventories.ContainsKey(0))
                 {
-                    if (item != null)
+                    if (item is not null)
                         inventories[0].Items[-1] = item;
                     else
                         inventories[0].Items.Remove(-1);
@@ -3191,7 +3184,7 @@ namespace MinecraftClient
             {
                 if (inventories.ContainsKey(inventoryID))
                 {
-                    if (item == null || item.IsEmpty)
+                    if (item is null || item.IsEmpty)
                     {
                         if (inventories[inventoryID].Items.ContainsKey(slotID))
                             inventories[inventoryID].Items.Remove(slotID);
@@ -3353,7 +3346,7 @@ namespace MinecraftClient
                 Entity entity = entities[entityid];
                 if (entity.Equipment.ContainsKey(slot))
                     entity.Equipment.Remove(slot);
-                if (item != null)
+                if (item is not null)
                     entity.Equipment[slot] = item;
                 DispatchBotEvent(bot => bot.OnEntityEquipment(entities[entityid], slot, item));
             }
@@ -3729,24 +3722,24 @@ namespace MinecraftClient
                 entity.Metadata = metadata;
                 int itemEntityMetadataFieldIndex = protocolversion < Protocol18Handler.MC_1_17_Version ? 7 : 8;
                 
-                if (entity.Type.ContainsItem() && metadata.TryGetValue(itemEntityMetadataFieldIndex, out object? itemObj) && itemObj != null && itemObj.GetType() == typeof(Item))
+                if (entity.Type.ContainsItem() && metadata.TryGetValue(itemEntityMetadataFieldIndex, out object? itemObj) && itemObj is not null && itemObj.GetType() == typeof(Item))
                 {
                     Item item = (Item)itemObj;
-                    if (item == null)
+                    if (item is null)
                         entity.Item = new Item(ItemType.Air, 0, null);
                     else entity.Item = item;
                 }
-                if (metadata.TryGetValue(6, out object? poseObj) && poseObj != null && poseObj.GetType() == typeof(Int32))
+                if (metadata.TryGetValue(6, out object? poseObj) && poseObj is not null && poseObj.GetType() == typeof(Int32))
                 {
                     entity.Pose = (EntityPose)poseObj;
                 }
-                if (metadata.TryGetValue(2, out object? nameObj) && nameObj != null && nameObj.GetType() == typeof(string))
+                if (metadata.TryGetValue(2, out object? nameObj) && nameObj is not null && nameObj.GetType() == typeof(string))
                 {
                     string name = nameObj.ToString() ?? string.Empty;
                     entity.CustomNameJson = name;
                     entity.CustomName = ChatParser.ParseText(name);
                 }
-                if (metadata.TryGetValue(3, out object? nameVisableObj) && nameVisableObj != null && nameVisableObj.GetType() == typeof(bool))
+                if (metadata.TryGetValue(3, out object? nameVisableObj) && nameVisableObj is not null && nameVisableObj.GetType() == typeof(bool))
                 {
                     entity.IsCustomNameVisible = bool.Parse(nameVisableObj.ToString() ?? string.Empty);
                 }

--- a/MinecraftClient/Physics/BlockShapes.cs
+++ b/MinecraftClient/Physics/BlockShapes.cs
@@ -39,7 +39,7 @@ namespace MinecraftClient.Physics
         /// </summary>
         public static Aabb[] GetShapes(int blockStateId)
         {
-            if (stateToShape != null && stateToShape.TryGetValue(blockStateId, out var shapes))
+            if (stateToShape is not null && stateToShape.TryGetValue(blockStateId, out var shapes))
                 return shapes;
             return FallbackShape(blockStateId);
         }
@@ -76,7 +76,7 @@ namespace MinecraftClient.Physics
             {
                 var assembly = Assembly.GetExecutingAssembly();
                 using var stream = assembly.GetManifestResourceStream("BlockShapeData.json");
-                if (stream == null)
+                if (stream is null)
                 {
                     ConsoleInteractive.ConsoleWriter.WriteLineFormatted("§e[Physics] BlockShapeData.json not found as embedded resource");
                     return;
@@ -138,12 +138,12 @@ namespace MinecraftClient.Physics
         {
             stateToShape = new Dictionary<int, Aabb[]>();
 
-            if (prismarineBlocks == null || prismarineShapes == null)
+            if (prismarineBlocks is null || prismarineShapes is null)
                 return;
 
             var palette = Block.Palette;
             var dict = GetPaletteDict(palette);
-            if (dict == null) return;
+            if (dict is null) return;
 
             // Group consecutive state IDs by Material to find state ranges per block
             var materialRanges = new Dictionary<Material, List<(int start, int end)>>();

--- a/MinecraftClient/Program.cs
+++ b/MinecraftClient/Program.cs
@@ -120,7 +120,7 @@ namespace MinecraftClient
             ConsoleIO.WriteLine($"Minecraft Console Client v{Version} - for MC {MCLowestVersion} to {MCHighestVersion} - Github.com/MCCTeam");
 
             //Build information to facilitate processing of bug reports
-            if (BuildInfo != null)
+            if (BuildInfo is not null)
                 ConsoleIO.WriteLineFormatted("§8" + BuildInfo);
 
             //Debug input ?
@@ -618,11 +618,11 @@ namespace MinecraftClient
                             ConsoleIO.WriteLineFormatted("§8" + string.Format(Translations.mcc_profile_key_valid, session.PlayerName));
                     }
 
-                    if (playerKeyPair == null || playerKeyPair.NeedRefresh())
+                    if (playerKeyPair is null || playerKeyPair.NeedRefresh())
                     {
                         ConsoleIO.WriteLineFormatted(Translations.mcc_fetching_key, acceptnewlines: true);
                         playerKeyPair = KeyUtils.GetNewProfileKeys(session.ID, Config.Main.General.AccountType == LoginType.yggdrasil);
-                        if (Config.Main.Advanced.ProfileKeyCache != CacheType.none && playerKeyPair != null)
+                        if (Config.Main.Advanced.ProfileKeyCache != CacheType.none && playerKeyPair is not null)
                         {
                             KeysCache.Store(loginLower, playerKeyPair);
                         }
@@ -630,7 +630,7 @@ namespace MinecraftClient
                 }
 
                 //Force-enable Forge support?
-                if (!isRealms && (Config.Main.Advanced.EnableForge == ForgeConfigType.force) && forgeInfo == null)
+                if (!isRealms && (Config.Main.Advanced.EnableForge == ForgeConfigType.force) && forgeInfo is null)
                 {
                     if (ProtocolHandler.ProtocolMayForceForge(protocolversion))
                     {
@@ -726,8 +726,8 @@ namespace MinecraftClient
             ConsoleInteractive.ConsoleReader.StopReadThread();
             new Thread(new ThreadStart(delegate
             {
-                if (client != null) { client.Disconnect(); ConsoleIO.Reset(); }
-                if (offlinePrompt != null) { offlinePrompt.Item2.Cancel(); offlinePrompt.Item1.Join(); offlinePrompt = null; ConsoleIO.Reset(); }
+                if (client is not null) { client.Disconnect(); ConsoleIO.Reset(); }
+                if (offlinePrompt is not null) { offlinePrompt.Item2.Cancel(); offlinePrompt.Item1.Join(); offlinePrompt = null; ConsoleIO.Reset(); }
                 if (delaySeconds > 0)
                 {
                     ConsoleIO.WriteLine(string.Format(Translations.mcc_restart_delay, delaySeconds));
@@ -745,8 +745,8 @@ namespace MinecraftClient
             ConsoleInteractive.ConsoleSuggestion.ClearSuggestions();
             ConsoleIO.WriteLineFormatted("§a" + string.Format(Translations.config_saving, settingsIniPath));
 
-            if (client != null) { client.Disconnect(); ConsoleIO.Reset(); }
-            if (offlinePrompt != null) { offlinePrompt.Item2.Cancel(); offlinePrompt.Item1.Join(); offlinePrompt = null; ConsoleIO.Reset(); }
+            if (client is not null) { client.Disconnect(); ConsoleIO.Reset(); }
+            if (offlinePrompt is not null) { offlinePrompt.Item2.Cancel(); offlinePrompt.Item1.Join(); offlinePrompt = null; ConsoleIO.Reset(); }
             if (Config.Main.Advanced.PlayerHeadAsIcon) { ConsoleIcon.RevertToMCCIcon(); }
             Environment.Exit(exitcode);
         }
@@ -803,7 +803,7 @@ namespace MinecraftClient
                         return; //AutoRelog is triggering a restart of the client, don't turn on the offline prompt
                 }
                 
-                if (offlinePrompt == null)
+                if (offlinePrompt is null)
                 {
                     ConsoleInteractive.ConsoleReader.StopReadThread();
 
@@ -909,7 +909,7 @@ namespace MinecraftClient
         /// <returns></returns>
         public static Type[] GetTypesInNamespace(string nameSpace, Assembly? assembly = null)
         {
-            if (assembly == null) { assembly = Assembly.GetExecutingAssembly(); }
+            if (assembly is null) { assembly = Assembly.GetExecutingAssembly(); }
             return assembly.GetTypes().Where(t => string.Equals(t.Namespace, nameSpace, StringComparison.Ordinal)).ToArray();
         }
 

--- a/MinecraftClient/Protocol/Handlers/DataTypes.cs
+++ b/MinecraftClient/Protocol/Handlers/DataTypes.cs
@@ -15,21 +15,12 @@ namespace MinecraftClient.Protocol.Handlers
     /// <summary>
     /// Handle data types encoding / decoding
     /// </summary>
-    public class DataTypes
+    public class DataTypes(int protocol)
     {
         /// <summary>
         /// Protocol version for adjusting data types
         /// </summary>
-        private readonly int protocolversion;
-
-        /// <summary>
-        /// Initialize a new DataTypes instance
-        /// </summary>
-        /// <param name="protocol">Protocol version</param>
-        public DataTypes(int protocol)
-        {
-            protocolversion = protocol;
-        }
+        private readonly int protocolversion = protocol;
 
         /// <summary>
         /// Protocol version used to adjust wire encodings.
@@ -461,7 +452,7 @@ namespace MinecraftClient.Protocol.Handlers
                         item.Components = strcturedComponentsToAdd;
 
                     return item;
-                case >= Protocol18Handler.MC_1_13_Version:
+                case >= Protocol18Handler.MC_1_13_2_Version:
                 {
                     var itemPresent = ReadNextBool(cache);
 
@@ -475,6 +466,18 @@ namespace MinecraftClient.Protocol.Handlers
 
                     var type = itemPalette.FromId(itemId); 
                     itemCount = ReadNextByte(cache); 
+                    nbt = ReadNextNbt(cache);
+                    return new Item(type, itemCount, nbt);
+                }
+                case >= Protocol18Handler.MC_1_13_Version:
+                {
+                    itemId = ReadNextShort(cache);
+
+                    if (itemId == -1)
+                        return null;
+
+                    var type = itemPalette.FromId(itemId);
+                    itemCount = ReadNextByte(cache);
                     nbt = ReadNextNbt(cache);
                     return new Item(type, itemCount, nbt);
                 }
@@ -973,7 +976,7 @@ namespace MinecraftClient.Protocol.Handlers
 
                 return data;
             }
-            catch(Exception ex)
+            catch (Exception)
             {
                 return new Dictionary<int, object?>();
             }
@@ -1350,8 +1353,8 @@ namespace MinecraftClient.Protocol.Handlers
         /// <returns>Byte array for this NBT tag</returns>
         private byte[] GetNbt(Dictionary<string, object>? nbt, bool root)
         {
-            if (nbt == null || nbt.Count == 0)
-                return new byte[] { 0 }; // TAG_End
+            if (nbt is null || nbt.Count == 0)
+                return [0]; // TAG_End
 
             List<byte> bytes = new();
 
@@ -1699,7 +1702,7 @@ namespace MinecraftClient.Protocol.Handlers
         {
             List<byte> slotData = new();
 
-            if (item == null || item.IsEmpty)
+            if (item is null || item.IsEmpty)
             {
                 slotData.AddRange(GetBool(false));
             }
@@ -1727,7 +1730,7 @@ namespace MinecraftClient.Protocol.Handlers
 
             if (protocolversion >= Protocol18Handler.MC_1_20_6_Version)
             {
-                if (item == null || item.IsEmpty)
+                if (item is null || item.IsEmpty)
                 {
                     slotData.AddRange(GetVarInt(0));
                 }
@@ -1736,7 +1739,7 @@ namespace MinecraftClient.Protocol.Handlers
                     slotData.AddRange(GetVarInt(item.Count));
                     slotData.AddRange(GetVarInt(itemPalette.ToId(item.Type)));
 
-                    if (item.Components != null && item.Components.Count > 0)
+                    if (item.Components is not null && item.Components.Count > 0)
                     {
                         slotData.AddRange(GetVarInt(item.Components.Count));
                         slotData.AddRange(GetVarInt(0)); // components to remove
@@ -1754,9 +1757,9 @@ namespace MinecraftClient.Protocol.Handlers
                     }
                 }
             }
-            else if (protocolversion > Protocol18Handler.MC_1_13_Version)
+            else if (protocolversion >= Protocol18Handler.MC_1_13_2_Version)
             {
-                if (item == null || item.IsEmpty)
+                if (item is null || item.IsEmpty)
                     slotData.AddRange(GetBool(false));
                 else
                 {
@@ -1766,15 +1769,27 @@ namespace MinecraftClient.Protocol.Handlers
                     slotData.AddRange(GetNbt(item.NBT));
                 }
             }
+            else if (protocolversion >= Protocol18Handler.MC_1_13_Version)
+            {
+                if (item is null || item.IsEmpty)
+                    slotData.AddRange(GetShort(-1));
+                else
+                {
+                    slotData.AddRange(GetShort((short)itemPalette.ToId(item.Type)));
+                    slotData.Add((byte)item.Count);
+                    slotData.AddRange(GetNbt(item.NBT));
+                }
+            }
             else
             {
-                if (item == null || item.IsEmpty)
+                if (item is null || item.IsEmpty)
                     slotData.AddRange(GetShort(-1));
                 else
                 {
                     slotData.AddRange(GetShort((short)(itemPalette.ToId(item.Type) >> 16)));
                     slotData.Add((byte)item.Count);
-                    slotData.Add((byte)item.Data);
+                    // Legacy (<1.13) item slot wire format uses a SHORT for item damage/data.
+                    slotData.AddRange(GetShort((short)item.Data));
                     slotData.AddRange(GetNbt(item.NBT));
                 }
             }
@@ -1849,7 +1864,7 @@ namespace MinecraftClient.Protocol.Handlers
         /// <returns>String representation</returns>
         public string ByteArrayToString(byte[]? bytes)
         {
-            if (bytes == null)
+            if (bytes is null)
                 return "null";
             else
                 return BitConverter.ToString(bytes).Replace("-", " ");
@@ -1890,7 +1905,7 @@ namespace MinecraftClient.Protocol.Handlers
         {
             List<byte> fields = new();
             fields.AddRange(GetLastSeenMessageList(ack.lastSeen, isOnlineMode));
-            if (!isOnlineMode || ack.lastReceived == null)
+            if (!isOnlineMode || ack.lastReceived is null)
                 fields.AddRange(GetBool(false)); // Has last received message
             else
             {

--- a/MinecraftClient/Protocol/Handlers/Forge/ForgeInfo.cs
+++ b/MinecraftClient/Protocol/Handlers/Forge/ForgeInfo.cs
@@ -11,17 +11,8 @@ namespace MinecraftClient.Protocol.Handlers.Forge
         /// <summary>
         /// Represents an individual forge mod.
         /// </summary>
-        public class ForgeMod
+        public record ForgeMod(string ModID, string Version)
         {
-            public ForgeMod(String ModID, String Version)
-            {
-                this.ModID = ModID;
-                this.Version = Version;
-            }
-
-            public readonly String ModID;
-            public readonly String Version;
-
             public override string ToString()
             {
                 return ModID + " v" + Version;

--- a/MinecraftClient/Protocol/Handlers/Packet/s2c/DeclareCommands.cs
+++ b/MinecraftClient/Protocol/Handlers/Packet/s2c/DeclareCommands.cs
@@ -235,7 +235,7 @@ namespace MinecraftClient.Protocol.Handlers.packet.s2c
                 return false;
 
             List<Tuple<string, string>> currentArguments = signedArguments;
-            if (signedCapture != null)
+            if (signedCapture is not null)
             {
                 currentArguments = new List<Tuple<string, string>>(signedArguments.Count + 1);
                 currentArguments.AddRange(signedArguments);
@@ -317,7 +317,7 @@ namespace MinecraftClient.Protocol.Handlers.packet.s2c
                 case CommandNodeKind.Literal:
                     return TryConsumeLiteral(command, position, node.Name!, out nextPosition);
                 case CommandNodeKind.Argument:
-                    if (node.Argument == null || !TryConsumeArgument(command, position, node.Argument.Value, out nextPosition))
+                    if (node.Argument is null || !TryConsumeArgument(command, position, node.Argument.Value, out nextPosition))
                         return false;
 
                     if (node.Argument.Value.IsSigned)
@@ -585,7 +585,7 @@ namespace MinecraftClient.Protocol.Handlers.packet.s2c
                 };
             }
 
-            if (name == null)
+            if (name is null)
             {
                 layout = s_unknownLegacyArgumentType;
                 return true;
@@ -729,54 +729,25 @@ namespace MinecraftClient.Protocol.Handlers.packet.s2c
             ForgeEnum
         }
 
-        private sealed class CommandNode
+        private sealed record CommandNode(
+            byte Flags,
+            int[] Children,
+            int RedirectNode = -1,
+            string? Name = null,
+            CommandArgumentDescriptor? Argument = null,
+            string? SuggestionsType = null,
+            int ParserId = -1)
         {
-            public byte Flags { get; }
-            public int[] Children { get; }
-            public int RedirectNode { get; }
-            public string? Name { get; }
-            public CommandArgumentDescriptor? Argument { get; }
-            public string? SuggestionsType { get; }
-            public int ParserId { get; }
-
             public CommandNodeKind Kind => (CommandNodeKind)(Flags & NodeTypeMask);
             public bool IsExecutable => (Flags & NodeExecutableFlag) != 0;
             public bool IsRestricted => (Flags & NodeRestrictedFlag) != 0;
-
-            public CommandNode(
-                byte flags,
-                int[] children,
-                int redirectNode = -1,
-                string? name = null,
-                CommandArgumentDescriptor? argument = null,
-                string? suggestionsType = null,
-                int parserId = -1)
-            {
-                Flags = flags;
-                Children = children;
-                RedirectNode = redirectNode;
-                Name = name;
-                Argument = argument;
-                SuggestionsType = suggestionsType;
-                ParserId = parserId;
-            }
         }
 
-        private readonly struct CommandArgumentDescriptor
-        {
-            public string Name { get; }
-            public ArgumentConsumption Consumption { get; }
-            public int TokenCount { get; }
-            public bool IsSigned { get; }
-
-            public CommandArgumentDescriptor(string name, ArgumentConsumption consumption, int tokenCount = 1, bool isSigned = false)
-            {
-                Name = name;
-                Consumption = consumption;
-                TokenCount = tokenCount;
-                IsSigned = isSigned;
-            }
-        }
+        private readonly record struct CommandArgumentDescriptor(
+            string Name,
+            ArgumentConsumption Consumption,
+            int TokenCount = 1,
+            bool IsSigned = false);
 
         private readonly struct ArgumentTypeLayout
         {

--- a/MinecraftClient/Protocol/Handlers/PacketPalettes/PacketPalette18.cs
+++ b/MinecraftClient/Protocol/Handlers/PacketPalettes/PacketPalette18.cs
@@ -4,7 +4,7 @@ namespace MinecraftClient.Protocol.Handlers.PacketPalettes
 {
     public class PacketPalette18 : PacketTypePalette
     {
-        private Dictionary<int, PacketTypesIn> typeIn = new Dictionary<int, PacketTypesIn>()
+        private Dictionary<int, PacketTypesIn> typeIn = new()
         {
             { 0x00, PacketTypesIn.KeepAlive },
             { 0x01, PacketTypesIn.JoinGame },
@@ -80,7 +80,7 @@ namespace MinecraftClient.Protocol.Handlers.PacketPalettes
             { 0x49, PacketTypesIn.UpdateEntityNBT }
         };
 
-        private Dictionary<int, PacketTypesOut> typeOut = new Dictionary<int, PacketTypesOut>()
+        private Dictionary<int, PacketTypesOut> typeOut = new()
         {
             { 0x00, PacketTypesOut.TeleportConfirm },
             { 0x01, PacketTypesOut.Unknown },

--- a/MinecraftClient/Protocol/Handlers/Protocol16.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol16.cs
@@ -251,7 +251,7 @@ namespace MinecraftClient.Protocol.Handlers
         /// <returns>Net read thread ID</returns>
         public int GetNetMainThreadId()
         {
-            return netRead != null ? netRead.Item1.ManagedThreadId : -1;
+            return netRead is not null ? netRead.Item1.ManagedThreadId : -1;
         }
 
         public bool SendCookieResponse(string name, byte[]? data)
@@ -268,7 +268,7 @@ namespace MinecraftClient.Protocol.Handlers
         {
             try
             {
-                if (netRead != null)
+                if (netRead is not null)
                 {
                     netRead.Item2.Cancel();
                     c.Close();
@@ -556,7 +556,7 @@ namespace MinecraftClient.Protocol.Handlers
                 string serverHash = CryptoHandler.GetServerHash(serverIDhash, serverPublicKey, secretKey);
 
                 bool needCheckSession = true;
-                if (session.ServerPublicKey != null && session.SessionPreCheckTask != null
+                if (session.ServerPublicKey is not null && session.SessionPreCheckTask is not null
                     && serverIDhash == session.ServerIDhash && Enumerable.SequenceEqual(serverPublicKey, session.ServerPublicKey))
                 {
                     session.SessionPreCheckTask.Wait();

--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -102,7 +102,7 @@ namespace MinecraftClient.Protocol.Handlers
         private int oldSamplesWeight = 1;
 
         private bool receiveDeclareCommands = false, receivePlayerInfo = false;
-        private object MessageSigningLock = new();
+        private readonly Lock MessageSigningLock = new();
         private Guid chatUuid = Guid.NewGuid();
         private int pendingAcknowledgments = 0, messageIndex = 0;
         private LastSeenMessagesCollector lastSeenMessagesCollector;
@@ -133,7 +133,7 @@ namespace MinecraftClient.Protocol.Handlers
             this.handler = handler;
             pForge = new Protocol18Forge(forgeInfo, protocolVersion, dataTypes, this, handler);
             pTerrain = new Protocol18Terrain(protocolVersion, dataTypes, handler);
-            packetPalette = new PacketTypeHandler(protocolVersion, forgeInfo != null).GetTypeHandler();
+            packetPalette = new PacketTypeHandler(protocolVersion, forgeInfo is not null).GetTypeHandler();
             log = handler.GetLogger();
             randomGen = RandomNumberGenerator.Create();
             lastSeenMessagesCollector = protocolVersion >= MC_1_19_3_Version ? new(20) : new(5);
@@ -524,7 +524,7 @@ namespace MinecraftClient.Protocol.Handlers
                                         else if (isDimension)
                                         {
                                             dimensionIdMap!.Add(i, entryId);
-                                            if (nbtData != null && handler.GetTerrainEnabled())
+                                            if (nbtData is not null && handler.GetTerrainEnabled())
                                                 World.StoreOneDimension(entryId, nbtData);
                                         }
                                         else if (isAttribute)
@@ -691,7 +691,7 @@ namespace MinecraftClient.Protocol.Handlers
             var responseHeader =
                 protocolVersion < MC_1_10_Version // After 1.10, the MC does not include resource pack hash in responses
                     ? dataTypes.ConcatBytes(DataTypes.GetVarInt(hash.Length), Encoding.UTF8.GetBytes(hash))
-                    : Array.Empty<byte>();
+                    : [];
 
             var basePacketData = protocolVersion >= MC_1_20_4_Version && uuid != Guid.Empty
                 ? dataTypes.ConcatBytes(responseHeader, DataTypes.GetUUID(uuid))
@@ -984,7 +984,7 @@ namespace MinecraftClient.Protocol.Handlers
                         else
                         {
                             var player = handler.GetPlayerInfo(senderUuid);
-                            verifyResult = player != null && player.VerifyMessage(signedChat, timestamp, salt,
+                            verifyResult = player is not null && player.VerifyMessage(signedChat, timestamp, salt,
                                 ref messageSignature);
                         }
 
@@ -1043,7 +1043,7 @@ namespace MinecraftClient.Protocol.Handlers
                         var messageTypeEnum =
                             ChatParser.ChatId2Type!.GetValueOrDefault(chatTypeId, ChatParser.MessageType.CHAT);
 
-                        if (targetName != null &&
+                        if (targetName is not null &&
                             (messageTypeEnum == ChatParser.MessageType.TEAM_MSG_COMMAND_INCOMING ||
                              messageTypeEnum == ChatParser.MessageType.TEAM_MSG_COMMAND_OUTGOING))
                             senderTeamName = Json.ParseJson(targetName)!["with"]![0]!
@@ -1052,7 +1052,7 @@ namespace MinecraftClient.Protocol.Handlers
                         if (string.IsNullOrWhiteSpace(senderDisplayName))
                         {
                             var player = handler.GetPlayerInfo(senderUuid);
-                            if (player != null && (player.DisplayName != null || player is { Name: not null }) &&
+                            if (player is not null && (player.DisplayName is not null || player is { Name: not null }) &&
                                 string.IsNullOrWhiteSpace(senderDisplayName))
                             {
                                 senderDisplayName = ChatParser.ParseText(player.DisplayName ?? player.Name);
@@ -1071,7 +1071,7 @@ namespace MinecraftClient.Protocol.Handlers
                         else
                         {
                             var player = handler.GetPlayerInfo(senderUuid);
-                            if (player == null || !player.IsMessageChainLegal())
+                            if (player is null || !player.IsMessageChainLegal())
                                 verifyResult = false;
                             else
                             {
@@ -1158,7 +1158,7 @@ namespace MinecraftClient.Protocol.Handlers
                         if (string.IsNullOrWhiteSpace(senderDisplayName))
                         {
                             var player = handler.GetPlayerInfo(senderUuid);
-                            if (player != null && (player.DisplayName != null || player.Name != null) &&
+                            if (player is not null && (player.DisplayName is not null || player.Name is not null) &&
                                 string.IsNullOrWhiteSpace(senderDisplayName))
                             {
                                 senderDisplayName = player.DisplayName ?? player.Name;
@@ -1170,7 +1170,7 @@ namespace MinecraftClient.Protocol.Handlers
                         }
 
                         bool verifyResult;
-                        if (!isOnlineMode || messageSignature == null)
+                        if (!isOnlineMode || messageSignature is null)
                             verifyResult = false;
                         else
                         {
@@ -1179,7 +1179,7 @@ namespace MinecraftClient.Protocol.Handlers
                             else
                             {
                                 var player = handler.GetPlayerInfo(senderUuid);
-                                if (player == null || !player.IsMessageChainLegal())
+                                if (player is null || !player.IsMessageChainLegal())
                                     verifyResult = false;
                                 else
                                 {
@@ -1336,7 +1336,7 @@ namespace MinecraftClient.Protocol.Handlers
                         {
                             var player = handler.GetPlayerInfo(senderUuid);
 
-                            if (player == null || !player.IsMessageChainLegal())
+                            if (player is null || !player.IsMessageChainLegal())
                                 verifyResult = false;
                             else
                             {
@@ -2017,7 +2017,7 @@ namespace MinecraftClient.Protocol.Handlers
                         // Warning: It is legal to include unloaded chunks in the UnloadChunk packet.
                         // Since chunks that have not been loaded are not recorded, this may result
                         // in loading chunks that should be unloaded and inaccurate statistics.
-                        if (handler.GetWorld()[chunkX, chunkZ] != null)
+                        if (handler.GetWorld()[chunkX, chunkZ] is not null)
                             Interlocked.Decrement(ref handler.GetWorld().chunkCnt);
 
                         handler.GetWorld()[chunkX, chunkZ] = null;
@@ -2061,7 +2061,7 @@ namespace MinecraftClient.Protocol.Handlers
                             else
                             {
                                 var playerGet = handler.GetPlayerInfo(playerUuid);
-                                if (playerGet == null)
+                                if (playerGet is null)
                                 {
                                     player = new(string.Empty, playerUuid);
                                     handler.OnPlayerJoin(player);
@@ -2221,7 +2221,7 @@ namespace MinecraftClient.Protocol.Handlers
                                     if (dataTypes.ReadNextBool(packetData))
                                     {
                                         var player = handler.GetPlayerInfo(uuid);
-                                        if (player != null)
+                                        if (player is not null)
                                             player.DisplayName = dataTypes.ReadNextString(packetData);
                                         else
                                             dataTypes.SkipNextString(packetData);
@@ -2365,7 +2365,7 @@ namespace MinecraftClient.Protocol.Handlers
                         for (var slotId = 0; slotId < elements; slotId++)
                         {
                             var item = dataTypes.ReadNextItemSlot(packetData, itemPalette);
-                            if (item != null)
+                            if (item is not null)
                                 inventorySlots[slotId] = item;
                         }
 
@@ -3109,7 +3109,7 @@ namespace MinecraftClient.Protocol.Handlers
         /// <returns>Net read thread ID</returns>
         public int GetNetMainThreadId()
         {
-            return netMain != null ? netMain.Item1.ManagedThreadId : -1;
+            return netMain is not null ? netMain.Item1.ManagedThreadId : -1;
         }
 
         /// <summary>
@@ -3119,12 +3119,12 @@ namespace MinecraftClient.Protocol.Handlers
         {
             try
             {
-                if (netMain != null)
+                if (netMain is not null)
                 {
                     netMain.Item2.Cancel();
                 }
 
-                if (netReader != null)
+                if (netReader is not null)
                 {
                     netReader.Item2.Cancel();
                     socketWrapper.Disconnect();
@@ -3212,7 +3212,7 @@ namespace MinecraftClient.Protocol.Handlers
             // 1.19 - 1.19.2
             if (protocolVersion is >= MC_1_19_Version and < MC_1_19_3_Version)
             {
-                if (playerKeyPair == null)
+                if (playerKeyPair is null)
                     fullLoginPacket.AddRange(dataTypes.GetBool(false)); // Has Sig Data
                 else
                 {
@@ -3371,7 +3371,7 @@ namespace MinecraftClient.Protocol.Handlers
             // 1.19 - 1.19.2
             if (protocolVersion is >= MC_1_19_Version and < MC_1_19_3_Version)
             {
-                if (playerKeyPair == null)
+                if (playerKeyPair is null)
                 {
                     encryptionResponse.AddRange(dataTypes.GetBool(true)); // Has Verify Token
                     encryptionResponse.AddRange(dataTypes.GetArray(RSAService.Encrypt(token, false))); // Verify Token
@@ -3486,9 +3486,9 @@ namespace MinecraftClient.Protocol.Handlers
                 return -1;
 
             var transactionId = DataTypes.GetVarInt(autocomplete_transaction_id);
-            var assumeCommand = new byte[] { 0x00 };
-            var hasPosition = new byte[] { 0x00 };
-            var tabCompletePacket = Array.Empty<byte>();
+            byte[] assumeCommand = [0x00];
+            byte[] hasPosition = [0x00];
+            byte[] tabCompletePacket = [];
 
             switch (protocolVersion)
             {
@@ -3622,7 +3622,7 @@ namespace MinecraftClient.Protocol.Handlers
                 }
 
                 ConsoleIO.WriteLineFormatted("§8" + string.Format(Translations.mcc_server_protocol, version,
-                    protocolVersion + (forgeInfo != null ? Translations.mcc_with_forge : "")));
+                    protocolVersion + (forgeInfo is not null ? Translations.mcc_with_forge : "")));
 
                 return true;
             }
@@ -3719,7 +3719,7 @@ namespace MinecraftClient.Protocol.Handlers
         public void Acknowledge(ChatMessage message)
         {
             var entry = message.ToLastSeenMessageEntry();
-            if (entry == null) return;
+            if (entry is null) return;
 
             if (protocolVersion >= MC_1_19_3_Version)
             {
@@ -3768,7 +3768,7 @@ namespace MinecraftClient.Protocol.Handlers
                 List<Tuple<string, string>>? needSigned = null;
                 bool canSignCommand = protocolVersion >= MC_1_19_Version &&
                                       isOnlineMode &&
-                                      playerKeyPair != null &&
+                                      playerKeyPair is not null &&
                                       Config.Signature.LoginWithSecureProfile &&
                                       Config.Signature.SignMessageInCommand;
 
@@ -3798,7 +3798,7 @@ namespace MinecraftClient.Protocol.Handlers
                     var timeNow = DateTimeOffset.UtcNow;
                     fields.AddRange(DataTypes.GetLong(timeNow.ToUnixTimeMilliseconds()));
 
-                    if (needSigned == null || needSigned.Count == 0)
+                    if (needSigned is null || needSigned.Count == 0)
                     {
                         fields.AddRange(DataTypes.GetLong(0));
                         fields.AddRange(DataTypes.GetVarInt(0));
@@ -3902,7 +3902,7 @@ namespace MinecraftClient.Protocol.Handlers
                         var timeNow = DateTimeOffset.UtcNow;
                         fields.AddRange(DataTypes.GetLong(timeNow.ToUnixTimeMilliseconds()));
 
-                        if (!isOnlineMode || playerKeyPair == null || !Config.Signature.LoginWithSecureProfile ||
+                        if (!isOnlineMode || playerKeyPair is null || !Config.Signature.LoginWithSecureProfile ||
                             !Config.Signature.SignChat)
                         {
                             fields.AddRange(DataTypes.GetLong(0)); // Salt: Long
@@ -4009,7 +4009,7 @@ namespace MinecraftClient.Protocol.Handlers
         {
             try
             {
-                SendPacket(PacketTypesOut.ClientStatus, new byte[] { 0 });
+                SendPacket(PacketTypesOut.ClientStatus, [0]);
                 return true;
             }
             catch (SocketException)
@@ -4064,7 +4064,7 @@ namespace MinecraftClient.Protocol.Handlers
 
                 fields.AddRange(protocolVersion >= MC_1_9_Version
                     ? DataTypes.GetVarInt(chatMode)
-                    : new byte[] { chatMode });
+                    : [chatMode]);
 
                 fields.Add(chatColors ? (byte)1 : (byte)0);
                 if (protocolVersion < MC_1_8_Version)
@@ -4163,7 +4163,7 @@ namespace MinecraftClient.Protocol.Handlers
                                 dataTypes.GetDouble(location.Y),
                                 protocolVersion < MC_1_8_Version
                                     ? dataTypes.GetDouble(location.Y + 1.62)
-                                    : Array.Empty<byte>(),
+                                    : [],
                                 dataTypes.GetDouble(location.Z),
                                 dataTypes.GetFloat(yaw.Value),
                                 dataTypes.GetFloat(pitch.Value),
@@ -4181,7 +4181,7 @@ namespace MinecraftClient.Protocol.Handlers
                                 dataTypes.GetDouble(location.Y),
                                 protocolVersion < MC_1_8_Version
                                     ? dataTypes.GetDouble(location.Y + 1.62)
-                                    : Array.Empty<byte>(),
+                                    : [],
                                 dataTypes.GetDouble(location.Z),
                                 new[] { flags });
                         }
@@ -4223,7 +4223,7 @@ namespace MinecraftClient.Protocol.Handlers
                                 dataTypes.GetDouble(location.Y),
                                 protocolVersion < MC_1_8_Version
                                     ? dataTypes.GetDouble(location.Y + 1.62)
-                                    : Array.Empty<byte>(),
+                                    : [],
                                 dataTypes.GetDouble(location.Z),
                                 dataTypes.GetFloat(yaw.Value),
                                 dataTypes.GetFloat(pitch.Value),
@@ -4241,7 +4241,7 @@ namespace MinecraftClient.Protocol.Handlers
                                 dataTypes.GetDouble(location.Y),
                                 protocolVersion < MC_1_8_Version
                                     ? dataTypes.GetDouble(location.Y + 1.62)
-                                    : Array.Empty<byte>(),
+                                    : [],
                                 dataTypes.GetDouble(location.Z),
                                 new[] { flags });
                         }
@@ -4549,7 +4549,7 @@ namespace MinecraftClient.Protocol.Handlers
                         if (playerInventory?.Items is null)
                             return false;
 
-                        var slotWindowIds = new int[]{ 36, 37, 38, 39, 40, 41, 42, 43, 44 }; 
+                        int[] slotWindowIds = [36, 37, 38, 39, 40, 41, 42, 43, 44]; 
                         var currentSlot = ((McClient)handler).GetCurrentSlot();
                         
                         playerInventory.Items.TryGetValue(slotWindowIds[currentSlot], out var item);
@@ -5105,7 +5105,7 @@ namespace MinecraftClient.Protocol.Handlers
 
         public bool SendPlayerSession(PlayerKeyPair? playerKeyPair)
         {
-            if (playerKeyPair == null || !isOnlineMode)
+            if (playerKeyPair is null || !isOnlineMode)
                 return false;
 
             if (protocolVersion >= MC_1_19_3_Version)

--- a/MinecraftClient/Protocol/Handlers/Protocol18Forge.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18Forge.cs
@@ -12,31 +12,16 @@ namespace MinecraftClient.Protocol.Handlers
     /// <summary>
     /// Handler for the Minecraft Forge protocol
     /// </summary>
-    class Protocol18Forge
+    class Protocol18Forge(ForgeInfo? forgeInfo, int protocolVersion, DataTypes dataTypes, Protocol18Handler protocol18, IMinecraftComHandler mcHandler)
     {
-        private readonly int protocolversion;
-        private readonly DataTypes dataTypes;
-        private readonly Protocol18Handler protocol18;
-        private readonly IMinecraftComHandler mcHandler;
+        private readonly int protocolversion = protocolVersion;
+        private readonly DataTypes dataTypes = dataTypes;
+        private readonly Protocol18Handler protocol18 = protocol18;
+        private readonly IMinecraftComHandler mcHandler = mcHandler;
 
-        private readonly ForgeInfo? forgeInfo;
+        private readonly ForgeInfo? forgeInfo = forgeInfo;
         private FMLHandshakeClientState fmlHandshakeState = FMLHandshakeClientState.START;
-        private bool ForgeEnabled() { return forgeInfo != null; }
-
-        /// <summary>
-        /// Initialize a new Forge protocol handler
-        /// </summary>
-        /// <param name="forgeInfo">Forge Server Information</param>
-        /// <param name="protocolVersion">Minecraft protocol version</param>
-        /// <param name="dataTypes">Minecraft data types handler</param>
-        public Protocol18Forge(ForgeInfo? forgeInfo, int protocolVersion, DataTypes dataTypes, Protocol18Handler protocol18, IMinecraftComHandler mcHandler)
-        {
-            this.forgeInfo = forgeInfo;
-            protocolversion = protocolVersion;
-            this.dataTypes = dataTypes;
-            this.protocol18 = protocol18;
-            this.mcHandler = mcHandler;
-        }
+        private bool ForgeEnabled() { return forgeInfo is not null; }
 
         /// <summary>
         /// Get Forge-Tagged server address

--- a/MinecraftClient/Protocol/Handlers/Protocol18Terrain.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18Terrain.cs
@@ -12,23 +12,11 @@ namespace MinecraftClient.Protocol.Handlers
     /// <summary>
     /// Terrain Decoding handler for Protocol18
     /// </summary>
-    class Protocol18Terrain
+    class Protocol18Terrain(int protocolVersion, DataTypes dataTypes, IMinecraftComHandler handler)
     {
-        private readonly int protocolversion;
-        private readonly DataTypes dataTypes;
-        private readonly IMinecraftComHandler handler;
-
-        /// <summary>
-        /// Initialize a new Terrain Decoder
-        /// </summary>
-        /// <param name="protocolVersion">Minecraft Protocol Version</param>
-        /// <param name="dataTypes">Minecraft Protocol Data Types</param>
-        public Protocol18Terrain(int protocolVersion, DataTypes dataTypes, IMinecraftComHandler handler)
-        {
-            protocolversion = protocolVersion;
-            this.dataTypes = dataTypes;
-            this.handler = handler;
-        }
+        private readonly int protocolversion = protocolVersion;
+        private readonly DataTypes dataTypes = dataTypes;
+        private readonly IMinecraftComHandler handler = handler;
 
         /// <summary>
         /// Reading the "Block states" field: consists of 4096 entries, representing all the blocks in the chunk section.

--- a/MinecraftClient/Protocol/Handlers/SocketWrapper.cs
+++ b/MinecraftClient/Protocol/Handlers/SocketWrapper.cs
@@ -29,7 +29,7 @@ namespace MinecraftClient.Protocol.Handlers
         /// <remarks>Silently dropped connection can only be detected by attempting to read/write data</remarks>
         public bool IsConnected()
         {
-            return c.Client != null && c.Connected;
+            return c.Client is not null && c.Connected;
         }
 
         /// <summary>

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/AttributeModifiersComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/AttributeModifiersComponent.cs
@@ -15,12 +15,12 @@ public class AttributeModifiersComponent(DataTypes dataTypes, ItemPalette itemPa
     
     public override void Parse(Queue<byte> data)
     {
-        NumberOfAttributes = dataTypes.ReadNextVarInt(data);
+        NumberOfAttributes = DataTypes.ReadNextVarInt(data);
 
         for (var i = 0; i < NumberOfAttributes; i++)
-            Attributes.Add(subComponentRegistry.ParseSubComponent(SubComponents.Attribute, data));
+            Attributes.Add(SubComponentRegistry.ParseSubComponent(SubComponents.Attribute, data));
 
-        ShowInTooltip = dataTypes.ReadNextBool(data);
+        ShowInTooltip = DataTypes.ReadNextBool(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/BannerPatternsComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/BannerPatternsComponent.cs
@@ -13,17 +13,17 @@ public class BannerPatternsComponent(DataTypes dataTypes, ItemPalette itemPalett
     
     public override void Parse(Queue<byte> data)
     {
-        NumberOfLayers = dataTypes.ReadNextVarInt(data);
+        NumberOfLayers = DataTypes.ReadNextVarInt(data);
 
         for (var i = 0; i < NumberOfLayers; i++)
         {
-            var patternType = dataTypes.ReadNextVarInt(data);
+            var patternType = DataTypes.ReadNextVarInt(data);
             Layers.Add(new BannerLayer
             {
                 PatternType = patternType,
-                AssetId = patternType == 0 ? dataTypes.ReadNextString(data) : null,
-                TranslationKey = patternType == 0 ? dataTypes.ReadNextString(data) : null,
-                DyeColor = dataTypes.ReadNextVarInt(data)
+                AssetId = patternType == 0 ? DataTypes.ReadNextString(data) : null,
+                TranslationKey = patternType == 0 ? DataTypes.ReadNextString(data) : null,
+                DyeColor = DataTypes.ReadNextVarInt(data)
             });
         }
     }
@@ -59,7 +59,7 @@ public class BannerPatternsComponent(DataTypes dataTypes, ItemPalette itemPalett
     }
 }
 
-public class BannerLayer
+public record BannerLayer
 {
     public int PatternType { get; set; }
     public string? AssetId { get; set; } = null!;

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/BaseColorComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/BaseColorComponent.cs
@@ -11,7 +11,7 @@ public class BaseColorComponent(DataTypes dataTypes, ItemPalette itemPalette, Su
     
     public override void Parse(Queue<byte> data)
     {
-        DyeColor = dataTypes.ReadNextVarInt(data);
+        DyeColor = DataTypes.ReadNextVarInt(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/BeesComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/BeesComponent.cs
@@ -14,10 +14,10 @@ public class BeesComponent(DataTypes dataTypes, ItemPalette itemPalette, SubComp
     
     public override void Parse(Queue<byte> data)
     {
-        NumberOfBees = dataTypes.ReadNextVarInt(data);
+        NumberOfBees = DataTypes.ReadNextVarInt(data);
         for (var i = 0; i < NumberOfBees; i++)
         {
-            Bees.Add(new Bee(dataTypes.ReadNextNbt(data), dataTypes.ReadNextVarInt(data), dataTypes.ReadNextVarInt(data)));
+            Bees.Add(new Bee(DataTypes.ReadNextNbt(data), DataTypes.ReadNextVarInt(data), DataTypes.ReadNextVarInt(data)));
         }
     }
 

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/BlockStateComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/BlockStateComponent.cs
@@ -11,9 +11,9 @@ public class BlockStateComponent(DataTypes dataTypes, ItemPalette itemPalette, S
     
     public override void Parse(Queue<byte> data)
     {
-        var count = dataTypes.ReadNextVarInt(data);
+        var count = DataTypes.ReadNextVarInt(data);
         for(var i = 0; i < count; i++)
-            Properties.Add((dataTypes.ReadNextString(data), dataTypes.ReadNextString(data)));
+            Properties.Add((DataTypes.ReadNextString(data), DataTypes.ReadNextString(data)));
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/BundleContentsComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/BundleContentsComponent.cs
@@ -12,12 +12,12 @@ public class BundleContentsComponent(DataTypes dataTypes, ItemPalette itemPalett
 
     public override void Parse(Queue<byte> data)
     {
-        var count = dataTypes.ReadNextVarInt(data);
+        var count = DataTypes.ReadNextVarInt(data);
 
         for (var i = 0; i < count; i++)
         {
-            var item = dataTypes.ReadNextItemSlot(data, itemPalette);
-            if (item != null)
+            var item = DataTypes.ReadNextItemSlot(data, ItemPalette);
+            if (item is not null)
                 Items.Add(item);
         }
     }
@@ -28,7 +28,7 @@ public class BundleContentsComponent(DataTypes dataTypes, ItemPalette itemPalett
         data.AddRange(DataTypes.GetVarInt(Items.Count));
 
         foreach (var item in Items)
-            data.AddRange(DataTypes.GetItemSlot(item, itemPalette));
+            data.AddRange(DataTypes.GetItemSlot(item, ItemPalette));
 
         return new Queue<byte>(data);
     }

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/CanBreakComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/CanBreakComponent.cs
@@ -16,12 +16,12 @@ public class CanBreakComponent(DataTypes dataTypes, ItemPalette itemPalette, Sub
     
     public override void Parse(Queue<byte> data)
     {
-        NumberOfPredicates = dataTypes.ReadNextVarInt(data);
+        NumberOfPredicates = DataTypes.ReadNextVarInt(data);
 
         for (var i = 0; i < NumberOfPredicates; i++)
-            BlockPredicates.Add((BlockPredicateSubcomponent)subComponentRegistry.ParseSubComponent(SubComponents.BlockPredicate, data));
+            BlockPredicates.Add((BlockPredicateSubcomponent)SubComponentRegistry.ParseSubComponent(SubComponents.BlockPredicate, data));
 
-        ShowInTooltip = dataTypes.ReadNextBool(data);
+        ShowInTooltip = DataTypes.ReadNextBool(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/CanPlaceOnComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/CanPlaceOnComponent.cs
@@ -16,12 +16,12 @@ public class CanPlaceOnComponent(DataTypes dataTypes, ItemPalette itemPalette, S
     
     public override void Parse(Queue<byte> data)
     {
-        NumberOfPredicates = dataTypes.ReadNextVarInt(data);
+        NumberOfPredicates = DataTypes.ReadNextVarInt(data);
 
         for (var i = 0; i < NumberOfPredicates; i++)
-            BlockPredicates.Add((BlockPredicateSubcomponent)subComponentRegistry.ParseSubComponent(SubComponents.BlockPredicate, data));
+            BlockPredicates.Add((BlockPredicateSubcomponent)SubComponentRegistry.ParseSubComponent(SubComponents.BlockPredicate, data));
 
-        ShowInTooltip = dataTypes.ReadNextBool(data);
+        ShowInTooltip = DataTypes.ReadNextBool(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/ChargedProjectilesComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/ChargedProjectilesComponent.cs
@@ -12,12 +12,12 @@ public class ChargedProjectilesComponent(DataTypes dataTypes, ItemPalette itemPa
 
     public override void Parse(Queue<byte> data)
     {
-        var count = dataTypes.ReadNextVarInt(data);
+        var count = DataTypes.ReadNextVarInt(data);
 
         for (var i = 0; i < count; i++)
         {
-            var item = dataTypes.ReadNextItemSlot(data, itemPalette);
-            if (item != null)
+            var item = DataTypes.ReadNextItemSlot(data, ItemPalette);
+            if (item is not null)
                 Items.Add(item);
         }
     }
@@ -28,7 +28,7 @@ public class ChargedProjectilesComponent(DataTypes dataTypes, ItemPalette itemPa
         data.AddRange(DataTypes.GetVarInt(Items.Count));
 
         foreach (var item in Items)
-            data.AddRange(DataTypes.GetItemSlot(item, itemPalette));
+            data.AddRange(DataTypes.GetItemSlot(item, ItemPalette));
 
         return new Queue<byte>(data);
     }

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/ContainerComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/ContainerComponent.cs
@@ -12,9 +12,9 @@ public class ContainerComponent(DataTypes dataTypes, ItemPalette itemPalette, Su
     
     public override void Parse(Queue<byte> data)
     {
-        var count = dataTypes.ReadNextVarInt(data);
+        var count = DataTypes.ReadNextVarInt(data);
         for (var i = 0; i < count; i++)
-            Items.Add(dataTypes.ReadNextItemSlot(data, ItemPalette));
+            Items.Add(DataTypes.ReadNextItemSlot(data, ItemPalette));
     }
 
     public override Queue<byte> Serialize()
@@ -22,7 +22,7 @@ public class ContainerComponent(DataTypes dataTypes, ItemPalette itemPalette, Su
         var data = new List<byte>();
         data.AddRange(DataTypes.GetVarInt(Items.Count));
         foreach (var item in Items)
-            data.AddRange(DataTypes.GetItemSlot(item, itemPalette));
+            data.AddRange(DataTypes.GetItemSlot(item, ItemPalette));
             
         return new Queue<byte>(data);
     }

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/ContainerLootComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/ContainerLootComponent.cs
@@ -11,7 +11,7 @@ public class ContainerLootComponent(DataTypes dataTypes, ItemPalette itemPalette
     
     public override void Parse(Queue<byte> data)
     {
-        Nbt = dataTypes.ReadNextNbt(data);
+        Nbt = DataTypes.ReadNextNbt(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/CustomDataComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/CustomDataComponent.cs
@@ -11,7 +11,7 @@ public class CustomDataComponent(DataTypes dataTypes, ItemPalette itemPalette, S
     
     public override void Parse(Queue<byte> data)
     {
-        Nbt = dataTypes.ReadNextNbt(data);
+        Nbt = DataTypes.ReadNextNbt(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/CustomModelDataComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/CustomModelDataComponent.cs
@@ -10,7 +10,7 @@ public class CustomModelDataComponent(DataTypes dataTypes, ItemPalette itemPalet
     
     public override void Parse(Queue<byte> data)
     {
-        Value = dataTypes.ReadNextVarInt(data);
+        Value = DataTypes.ReadNextVarInt(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/CustomNameComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/CustomNameComponent.cs
@@ -13,7 +13,7 @@ public class CustomNameComponent(DataTypes dataTypes, ItemPalette itemPalette, S
     
     public override void Parse(Queue<byte> data)
     {
-        CustomNameNbt = dataTypes.ReadNextNbt(data);
+        CustomNameNbt = DataTypes.ReadNextNbt(data);
         CustomName = ChatParser.ParseText(CustomNameNbt);
     }
 

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/DamageComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/DamageComponent.cs
@@ -11,7 +11,7 @@ public class DamageComponent(DataTypes dataTypes, ItemPalette itemPalette, SubCo
     
     public override void Parse(Queue<byte> data)
     {
-        Damage = dataTypes.ReadNextVarInt(data);
+        Damage = DataTypes.ReadNextVarInt(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/DebugStickStateComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/DebugStickStateComponent.cs
@@ -11,7 +11,7 @@ public class DebugStickStateComponent(DataTypes dataTypes, ItemPalette itemPalet
     
     public override void Parse(Queue<byte> data)
     {
-        Nbt = dataTypes.ReadNextNbt(data);
+        Nbt = DataTypes.ReadNextNbt(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/DyeColorComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/DyeColorComponent.cs
@@ -12,8 +12,8 @@ public class DyeColorComponent(DataTypes dataTypes, ItemPalette itemPalette, Sub
     
     public override void Parse(Queue<byte> data)
     {
-        Color = dataTypes.ReadNextInt(data);
-        ShowInTooltip = dataTypes.ReadNextBool(data);
+        Color = DataTypes.ReadNextInt(data);
+        ShowInTooltip = DataTypes.ReadNextBool(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/EnchantmentGlintOverrideComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/EnchantmentGlintOverrideComponent.cs
@@ -11,7 +11,7 @@ public class EnchantmentGlintOverrideComponent(DataTypes dataTypes, ItemPalette 
     
     public override void Parse(Queue<byte> data)
     {
-        HasGlint = dataTypes.ReadNextBool(data);
+        HasGlint = DataTypes.ReadNextBool(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/EnchantmentsComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/EnchantmentsComponent.cs
@@ -14,16 +14,16 @@ public class EnchantmentsComponent(DataTypes dataTypes, ItemPalette itemPalette,
 
     public override void Parse(Queue<byte> data)
     {
-        NumberOfEnchantments = dataTypes.ReadNextVarInt(data);
+        NumberOfEnchantments = DataTypes.ReadNextVarInt(data);
 
         for (var i = 0; i < NumberOfEnchantments; i++)
         {
-            var registryId = dataTypes.ReadNextVarInt(data);
-            var level = dataTypes.ReadNextVarInt(data);
+            var registryId = DataTypes.ReadNextVarInt(data);
+            var level = DataTypes.ReadNextVarInt(data);
             Enchantments.Add(new Enchantment(EnchantmentMapping.GetEnchantmentByRegistryId1206(registryId), level));
         }
 
-        ShowTooltip = dataTypes.ReadNextBool(data);
+        ShowTooltip = DataTypes.ReadNextBool(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/EntityDataComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/EntityDataComponent.cs
@@ -11,7 +11,7 @@ public class EntityDataComponent(DataTypes dataTypes, ItemPalette itemPalette, S
     
     public override void Parse(Queue<byte> data)
     {
-        Nbt = dataTypes.ReadNextNbt(data);
+        Nbt = DataTypes.ReadNextNbt(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/FireworkExplosionComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/FireworkExplosionComponent.cs
@@ -15,7 +15,7 @@ public class FireworkExplosionComponent(DataTypes dataTypes, ItemPalette itemPal
     
     public override void Parse(Queue<byte> data)
     {
-        FireworkExplosionSubComponent = (FireworkExplosionSubComponent)subComponentRegistry.ParseSubComponent(SubComponents.FireworkExplosion, data);
+        FireworkExplosionSubComponent = (FireworkExplosionSubComponent)SubComponentRegistry.ParseSubComponent(SubComponents.FireworkExplosion, data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/FireworksComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/FireworksComponent.cs
@@ -19,14 +19,14 @@ public class FireworksComponent(DataTypes dataTypes, ItemPalette itemPalette, Su
     
     public override void Parse(Queue<byte> data)
     {
-        FlightDuration = dataTypes.ReadNextVarInt(data);
-        NumberOfExplosions = dataTypes.ReadNextVarInt(data);
+        FlightDuration = DataTypes.ReadNextVarInt(data);
+        NumberOfExplosions = DataTypes.ReadNextVarInt(data);
 
         if (NumberOfExplosions > 0)
         {
             for(var i = 0; i < NumberOfExplosions; i++)
                 Explosions.Add(
-                    (FireworkExplosionSubComponent)subComponentRegistry.ParseSubComponent(SubComponents.FireworkExplosion,
+                    (FireworkExplosionSubComponent)SubComponentRegistry.ParseSubComponent(SubComponents.FireworkExplosion,
                         data));
         }
     }

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/FoodComponentComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/FoodComponentComponent.cs
@@ -18,14 +18,14 @@ public class FoodComponentComponent(DataTypes dataTypes, ItemPalette itemPalette
     
     public override void Parse(Queue<byte> data)
     {
-        Nutrition = dataTypes.ReadNextVarInt(data);
-        Saturation = dataTypes.ReadNextFloat(data);
-        CanAlwaysEat = dataTypes.ReadNextBool(data);
-        SecondsToEat = dataTypes.ReadNextFloat(data);
-        var numberOfEffects = dataTypes.ReadNextVarInt(data);
+        Nutrition = DataTypes.ReadNextVarInt(data);
+        Saturation = DataTypes.ReadNextFloat(data);
+        CanAlwaysEat = DataTypes.ReadNextBool(data);
+        SecondsToEat = DataTypes.ReadNextFloat(data);
+        var numberOfEffects = DataTypes.ReadNextVarInt(data);
         
         for(var i = 0; i < numberOfEffects; i++)
-            Effects.Add((EffectSubComponent)subComponentRegistry.ParseSubComponent(SubComponents.Effect, data));
+            Effects.Add((EffectSubComponent)SubComponentRegistry.ParseSubComponent(SubComponents.Effect, data));
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/InstrumentComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/InstrumentComponent.cs
@@ -23,22 +23,22 @@ public class InstrumentComponent(DataTypes dataTypes, ItemPalette itemPalette, S
     
     public override void Parse(Queue<byte> data)
     {
-        InstrumentHolderId = dataTypes.ReadNextVarInt(data);
+        InstrumentHolderId = DataTypes.ReadNextVarInt(data);
 
         if (InstrumentHolderId == 0)
         {
-            SoundEventHolderId = dataTypes.ReadNextVarInt(data);
+            SoundEventHolderId = DataTypes.ReadNextVarInt(data);
 
             if (SoundEventHolderId == 0)
             {
-                SoundLocation = dataTypes.ReadNextString(data);
-                HasFixedRange = dataTypes.ReadNextBool(data);
+                SoundLocation = DataTypes.ReadNextString(data);
+                HasFixedRange = DataTypes.ReadNextBool(data);
                 if (HasFixedRange)
-                    FixedRange = dataTypes.ReadNextFloat(data);
+                    FixedRange = DataTypes.ReadNextFloat(data);
             }
 
-            UseDuration = dataTypes.ReadNextVarInt(data);
-            Range = dataTypes.ReadNextFloat(data);
+            UseDuration = DataTypes.ReadNextVarInt(data);
+            Range = DataTypes.ReadNextFloat(data);
         }
     }
 

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/IntangibleProjectileComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/IntangibleProjectileComponent.cs
@@ -11,7 +11,7 @@ public class IntangibleProjectileComponent(DataTypes dataTypes, ItemPalette item
     
     public override void Parse(Queue<byte> data)
     {
-        Nbt = dataTypes.ReadNextNbt(data);
+        Nbt = DataTypes.ReadNextNbt(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/ItemNameComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/ItemNameComponent.cs
@@ -13,7 +13,7 @@ public class ItemNameComponent(DataTypes dataTypes, ItemPalette itemPalette, Sub
     
     public override void Parse(Queue<byte> data)
     {
-        ItemNameNbt = dataTypes.ReadNextNbt(data);
+        ItemNameNbt = DataTypes.ReadNextNbt(data);
         ItemName = ChatParser.ParseText(ItemNameNbt);
     }
 

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/LockComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/LockComponent.cs
@@ -11,7 +11,7 @@ public class LockComponent(DataTypes dataTypes, ItemPalette itemPalette, SubComp
     
     public override void Parse(Queue<byte> data)
     {
-        Nbt = dataTypes.ReadNextNbt(data);
+        Nbt = DataTypes.ReadNextNbt(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/LodestoneTrackerComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/LodestoneTrackerComponent.cs
@@ -15,15 +15,15 @@ public class LodestoneTrackerComponent(DataTypes dataTypes, ItemPalette itemPale
     
     public override void Parse(Queue<byte> data)
     {
-        HasGlobalPosition = dataTypes.ReadNextBool(data);
+        HasGlobalPosition = DataTypes.ReadNextBool(data);
 
         if (HasGlobalPosition)
         {
-            Dimension = dataTypes.ReadNextString(data);
-            Position = dataTypes.ReadNextLocation(data);
+            Dimension = DataTypes.ReadNextString(data);
+            Position = DataTypes.ReadNextLocation(data);
         }
         
-        Tracked = dataTypes.ReadNextBool(data);
+        Tracked = DataTypes.ReadNextBool(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/LoreComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/LoreComponent.cs
@@ -14,13 +14,13 @@ public class LoreNameComponent1206(DataTypes dataTypes, ItemPalette itemPalette,
     
     public override void Parse(Queue<byte> data)
     {
-        NumberOfLines = dataTypes.ReadNextVarInt(data);
+        NumberOfLines = DataTypes.ReadNextVarInt(data);
         
         if (NumberOfLines <= 0) return;
         
         for (var i = 0; i < NumberOfLines; i++)
         {
-            var lineNbt = dataTypes.ReadNextNbt(data);
+            var lineNbt = DataTypes.ReadNextNbt(data);
             LinesNbt.Add(lineNbt);
             Lines.Add(ChatParser.ParseText(lineNbt));
         }

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/MapColorComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/MapColorComponent.cs
@@ -11,7 +11,7 @@ public class MapColorComponent(DataTypes dataTypes, ItemPalette itemPalette, Sub
     
     public override void Parse(Queue<byte> data)
     {
-        Id = dataTypes.ReadNextInt(data);
+        Id = DataTypes.ReadNextInt(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/MapDecorationsComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/MapDecorationsComponent.cs
@@ -11,7 +11,7 @@ public class MapDecorationsComponent(DataTypes dataTypes, ItemPalette itemPalett
     
     public override void Parse(Queue<byte> data)
     {
-        Nbt = dataTypes.ReadNextNbt(data);
+        Nbt = DataTypes.ReadNextNbt(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/MapIdComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/MapIdComponent.cs
@@ -11,7 +11,7 @@ public class MapIdComponent(DataTypes dataTypes, ItemPalette itemPalette, SubCom
     
     public override void Parse(Queue<byte> data)
     {
-        Id = dataTypes.ReadNextVarInt(data);
+        Id = DataTypes.ReadNextVarInt(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/MapPostProcessingComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/MapPostProcessingComponent.cs
@@ -11,7 +11,7 @@ public class MapPostProcessingComponent(DataTypes dataTypes, ItemPalette itemPal
     
     public override void Parse(Queue<byte> data)
     {
-        Type = dataTypes.ReadNextVarInt(data);
+        Type = DataTypes.ReadNextVarInt(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/MaxDamageComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/MaxDamageComponent.cs
@@ -11,7 +11,7 @@ public class MaxDamageComponent(DataTypes dataTypes, ItemPalette itemPalette, Su
     
     public override void Parse(Queue<byte> data)
     {
-        MaxDamage = dataTypes.ReadNextVarInt(data);
+        MaxDamage = DataTypes.ReadNextVarInt(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/MaxStackSizeComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/MaxStackSizeComponent.cs
@@ -11,7 +11,7 @@ public class MaxStackSizeComponent(DataTypes dataTypes, ItemPalette itemPalette,
     
     public override void Parse(Queue<byte> data)
     {
-        MaxStackSize = dataTypes.ReadNextVarInt(data);
+        MaxStackSize = DataTypes.ReadNextVarInt(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/NoteBlockSoundComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/NoteBlockSoundComponent.cs
@@ -11,7 +11,7 @@ public class NoteBlockSoundComponent(DataTypes dataTypes, ItemPalette itemPalett
     
     public override void Parse(Queue<byte> data)
     {
-        Identifier = dataTypes.ReadNextString(data);
+        Identifier = DataTypes.ReadNextString(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/OmniousBottleAmplifierComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/OmniousBottleAmplifierComponent.cs
@@ -11,7 +11,7 @@ public class OmniousBottleAmplifierComponent(DataTypes dataTypes, ItemPalette it
     
     public override void Parse(Queue<byte> data)
     {
-        Amplifier = dataTypes.ReadNextVarInt(data);
+        Amplifier = DataTypes.ReadNextVarInt(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/PotDecorationsComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/PotDecorationsComponent.cs
@@ -11,9 +11,9 @@ public class PotDecorationsComponent(DataTypes dataTypes, ItemPalette itemPalett
     
     public override void Parse(Queue<byte> data)
     {
-        var count = dataTypes.ReadNextVarInt(data);
+        var count = DataTypes.ReadNextVarInt(data);
         for(var i = 0; i < count; i++)
-            Items.Add(dataTypes.ReadNextVarInt(data));
+            Items.Add(DataTypes.ReadNextVarInt(data));
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/PotionContentsComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/PotionContentsComponent.cs
@@ -17,17 +17,17 @@ public class PotionContentsComponent(DataTypes dataTypes, ItemPalette itemPalett
     
     public override void Parse(Queue<byte> data)
     {
-        HasPotionId = dataTypes.ReadNextBool(data);
+        HasPotionId = DataTypes.ReadNextBool(data);
         if (HasPotionId)
-            PotionId = dataTypes.ReadNextVarInt(data);
+            PotionId = DataTypes.ReadNextVarInt(data);
 
-        HasCustomColor = dataTypes.ReadNextBool(data);
+        HasCustomColor = DataTypes.ReadNextBool(data);
         if (HasCustomColor)
-            CustomColor = dataTypes.ReadNextInt(data);
+            CustomColor = DataTypes.ReadNextInt(data);
 
-        var numberOfEffects = dataTypes.ReadNextVarInt(data);
+        var numberOfEffects = DataTypes.ReadNextVarInt(data);
         for (var i = 0; i < numberOfEffects; i++)
-            Effects.Add((PotionEffectSubComponent)subComponentRegistry.ParseSubComponent(SubComponents.PotionEffect, data));
+            Effects.Add((PotionEffectSubComponent)SubComponentRegistry.ParseSubComponent(SubComponents.PotionEffect, data));
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/ProfileComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/ProfileComponent.cs
@@ -23,7 +23,7 @@ public class ProfileComponent(DataTypes dataTypes, ItemPalette itemPalette, SubC
     {
         ResetState();
 
-        if (dataTypes.ProtocolVersion >= Protocol18Handler.MC_1_21_9_Version)
+        if (DataTypes.ProtocolVersion >= Protocol18Handler.MC_1_21_9_Version)
         {
             ParseResolvableProfile(data);
             return;
@@ -34,7 +34,7 @@ public class ProfileComponent(DataTypes dataTypes, ItemPalette itemPalette, SubC
 
     public override Queue<byte> Serialize()
     {
-        return dataTypes.ProtocolVersion >= Protocol18Handler.MC_1_21_9_Version
+        return DataTypes.ProtocolVersion >= Protocol18Handler.MC_1_21_9_Version
             ? SerializeResolvableProfile()
             : SerializeLegacyProfile();
     }
@@ -56,44 +56,44 @@ public class ProfileComponent(DataTypes dataTypes, ItemPalette itemPalette, SubC
 
     private void ParseLegacyProfile(Queue<byte> data)
     {
-        HasName = dataTypes.ReadNextBool(data);
+        HasName = DataTypes.ReadNextBool(data);
 
         if (HasName)
-            Name = dataTypes.ReadNextString(data);
+            Name = DataTypes.ReadNextString(data);
 
-        HasUniqueId = dataTypes.ReadNextBool(data);
+        HasUniqueId = DataTypes.ReadNextBool(data);
 
         if (HasUniqueId)
-            Uuid = dataTypes.ReadNextUUID(data);
+            Uuid = DataTypes.ReadNextUUID(data);
 
-        NumberOfProperties = dataTypes.ReadNextVarInt(data);
+        NumberOfProperties = DataTypes.ReadNextVarInt(data);
         ProfileProperties = ReadProfileProperties(data, NumberOfProperties);
     }
 
     private void ParseResolvableProfile(Queue<byte> data)
     {
-        IsFullProfile = dataTypes.ReadNextBool(data);
+        IsFullProfile = DataTypes.ReadNextBool(data);
 
         if (IsFullProfile)
         {
             HasUniqueId = true;
-            Uuid = dataTypes.ReadNextUUID(data);
+            Uuid = DataTypes.ReadNextUUID(data);
             HasName = true;
-            Name = dataTypes.ReadNextString(data);
-            NumberOfProperties = dataTypes.ReadNextVarInt(data);
+            Name = DataTypes.ReadNextString(data);
+            NumberOfProperties = DataTypes.ReadNextVarInt(data);
             ProfileProperties = ReadProfileProperties(data, NumberOfProperties);
         }
         else
         {
-            HasName = dataTypes.ReadNextBool(data);
+            HasName = DataTypes.ReadNextBool(data);
             if (HasName)
-                Name = dataTypes.ReadNextString(data);
+                Name = DataTypes.ReadNextString(data);
 
-            HasUniqueId = dataTypes.ReadNextBool(data);
+            HasUniqueId = DataTypes.ReadNextBool(data);
             if (HasUniqueId)
-                Uuid = dataTypes.ReadNextUUID(data);
+                Uuid = DataTypes.ReadNextUUID(data);
 
-            NumberOfProperties = dataTypes.ReadNextVarInt(data);
+            NumberOfProperties = DataTypes.ReadNextVarInt(data);
             ProfileProperties = ReadProfileProperties(data, NumberOfProperties);
         }
 
@@ -101,8 +101,8 @@ public class ProfileComponent(DataTypes dataTypes, ItemPalette itemPalette, SubC
         CapeAssetId = ReadOptionalResourceLocation(data);
         ElytraAssetId = ReadOptionalResourceLocation(data);
 
-        if (dataTypes.ReadNextBool(data))
-            Model = dataTypes.ReadNextBool(data) ? ProfileSkinModel.Slim : ProfileSkinModel.Wide;
+        if (DataTypes.ReadNextBool(data))
+            Model = DataTypes.ReadNextBool(data) ? ProfileSkinModel.Slim : ProfileSkinModel.Wide;
     }
 
     private Queue<byte> SerializeLegacyProfile()
@@ -171,7 +171,7 @@ public class ProfileComponent(DataTypes dataTypes, ItemPalette itemPalette, SubC
 
         data.AddRange(DataTypes.GetBool(Model.HasValue));
         if (Model.HasValue)
-            data.AddRange(dataTypes.GetBool(Model.Value == ProfileSkinModel.Slim));
+            data.AddRange(DataTypes.GetBool(Model.Value == ProfileSkinModel.Slim));
 
         return new Queue<byte>(data);
     }
@@ -181,10 +181,10 @@ public class ProfileComponent(DataTypes dataTypes, ItemPalette itemPalette, SubC
         var properties = new List<ProfileProperty>(count);
         for (var i = 0; i < count; i++)
         {
-            var propertyName = dataTypes.ReadNextString(data);
-            var propertyValue = dataTypes.ReadNextString(data);
-            var hasSignature = dataTypes.ReadNextBool(data);
-            var signature = hasSignature ? dataTypes.ReadNextString(data) : null;
+            var propertyName = DataTypes.ReadNextString(data);
+            var propertyValue = DataTypes.ReadNextString(data);
+            var hasSignature = DataTypes.ReadNextBool(data);
+            var signature = hasSignature ? DataTypes.ReadNextString(data) : null;
 
             properties.Add(new ProfileProperty(propertyName, propertyValue, hasSignature, signature));
         }
@@ -211,7 +211,7 @@ public class ProfileComponent(DataTypes dataTypes, ItemPalette itemPalette, SubC
 
     private string? ReadOptionalResourceLocation(Queue<byte> data)
     {
-        return dataTypes.ReadNextBool(data) ? dataTypes.ReadNextString(data) : null;
+        return DataTypes.ReadNextBool(data) ? DataTypes.ReadNextString(data) : null;
     }
 
     private void SerializeOptionalResourceLocation(List<byte> data, string? resourceLocation)

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/RarityComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/RarityComponent.cs
@@ -12,7 +12,7 @@ public class RarityComponent(DataTypes dataTypes, ItemPalette itemPalette, SubCo
     
     public override void Parse(Queue<byte> data)
     {
-        Rarity = (ItemRarity)dataTypes.ReadNextVarInt(data);
+        Rarity = (ItemRarity)DataTypes.ReadNextVarInt(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/RecipesComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/RecipesComponent.cs
@@ -11,7 +11,7 @@ public class RecipesComponent(DataTypes dataTypes, ItemPalette itemPalette, SubC
     
     public override void Parse(Queue<byte> data)
     {
-        Nbt = dataTypes.ReadNextNbt(data);
+        Nbt = DataTypes.ReadNextNbt(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/RepairCostComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/RepairCostComponent.cs
@@ -11,7 +11,7 @@ public class RepairCostComponent(DataTypes dataTypes, ItemPalette itemPalette, S
     
     public override void Parse(Queue<byte> data)
     {
-        Cost = dataTypes.ReadNextVarInt(data);
+        Cost = DataTypes.ReadNextVarInt(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/SuspiciousStewEffectsComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/SuspiciousStewEffectsComponent.cs
@@ -15,10 +15,10 @@ public class SuspiciousStewEffectsComponent(DataTypes dataTypes, ItemPalette ite
 
     public override void Parse(Queue<byte> data)
     {
-        NumberOfEffects = dataTypes.ReadNextVarInt(data);
+        NumberOfEffects = DataTypes.ReadNextVarInt(data);
 
         for (var i = 0; i < NumberOfEffects; i++)
-            Effects.Add(new SuspiciousStewEffect(dataTypes.ReadNextVarInt(data), dataTypes.ReadNextVarInt(data)));
+            Effects.Add(new SuspiciousStewEffect(DataTypes.ReadNextVarInt(data), DataTypes.ReadNextVarInt(data)));
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/ToolComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/ToolComponent.cs
@@ -17,13 +17,13 @@ public class ToolComponent(DataTypes dataTypes, ItemPalette itemPalette, SubComp
     
     public override void Parse(Queue<byte> data)
     {
-        NumberOfRules = dataTypes.ReadNextVarInt(data);
+        NumberOfRules = DataTypes.ReadNextVarInt(data);
 
         for (var i = 0; i < NumberOfRules; i++)
-            Rules.Add((RuleSubComponent)subComponentRegistry.ParseSubComponent(SubComponents.Rule, data));
+            Rules.Add((RuleSubComponent)SubComponentRegistry.ParseSubComponent(SubComponents.Rule, data));
 
-        DefaultMiningSpeed = dataTypes.ReadNextFloat(data);
-        DamagePerBlock = dataTypes.ReadNextVarInt(data);
+        DefaultMiningSpeed = DataTypes.ReadNextFloat(data);
+        DamagePerBlock = DataTypes.ReadNextVarInt(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/TrimComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/TrimComponent.cs
@@ -27,40 +27,40 @@ public class TrimComponent(DataTypes dataTypes, ItemPalette itemPalette, SubComp
     
     public override void Parse(Queue<byte> data)
     {
-        TrimMaterialType = dataTypes.ReadNextVarInt(data);
+        TrimMaterialType = DataTypes.ReadNextVarInt(data);
 
         if (TrimMaterialType == 0)
         {
-            AssetName = dataTypes.ReadNextString(data);
-            Ingredient = dataTypes.ReadNextVarInt(data);
-            ItemModelIndex = dataTypes.ReadNextFloat(data);
-            NumberOfOverrides = dataTypes.ReadNextVarInt(data);
+            AssetName = DataTypes.ReadNextString(data);
+            Ingredient = DataTypes.ReadNextVarInt(data);
+            ItemModelIndex = DataTypes.ReadNextFloat(data);
+            NumberOfOverrides = DataTypes.ReadNextVarInt(data);
 
             if (NumberOfOverrides > 0)
             {
                 Overrides = [];
 
                 for (var i = 0; i < NumberOfOverrides; i++)
-                    Overrides.Add(new TrimAssetOverride(dataTypes.ReadNextVarInt(data),
-                        dataTypes.ReadNextString(data)));
+                    Overrides.Add(new TrimAssetOverride(DataTypes.ReadNextVarInt(data),
+                        DataTypes.ReadNextString(data)));
             }
 
-            DescriptionNbt = dataTypes.ReadNextNbt(data);
+            DescriptionNbt = DataTypes.ReadNextNbt(data);
             Description = ChatParser.ParseText(DescriptionNbt);
         }
 
-        TrimPatternType = dataTypes.ReadNextVarInt(data);
+        TrimPatternType = DataTypes.ReadNextVarInt(data);
 
         if (TrimPatternType == 0)
         {
-            TrimPatternTypeAssetName = dataTypes.ReadNextString(data);
-            TemplateItem = dataTypes.ReadNextVarInt(data);
-            TrimPatternTypeDescriptionNbt = dataTypes.ReadNextNbt(data);
+            TrimPatternTypeAssetName = DataTypes.ReadNextString(data);
+            TemplateItem = DataTypes.ReadNextVarInt(data);
+            TrimPatternTypeDescriptionNbt = DataTypes.ReadNextNbt(data);
             TrimPatternTypeDescription = ChatParser.ParseText(TrimPatternTypeDescriptionNbt);
-            Decal = dataTypes.ReadNextBool(data);
+            Decal = DataTypes.ReadNextBool(data);
         }
 
-        ShowInTooltip = dataTypes.ReadNextBool(data);
+        ShowInTooltip = DataTypes.ReadNextBool(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/UnbreakableComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/UnbreakableComponent.cs
@@ -11,7 +11,7 @@ public class UnbrekableComponent1206(DataTypes dataTypes, ItemPalette itemPalett
     
     public override void Parse(Queue<byte> data)
     {
-        Unbrekable = dataTypes.ReadNextBool(data);
+        Unbrekable = DataTypes.ReadNextBool(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/WritableBlookContentComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/WritableBlookContentComponent.cs
@@ -12,16 +12,16 @@ public class WritableBlookContentComponent(DataTypes dataTypes, ItemPalette item
     
     public override void Parse(Queue<byte> data)
     {
-        var count = dataTypes.ReadNextVarInt(data);
+        var count = DataTypes.ReadNextVarInt(data);
 
         for (var i = 0; i < count; i++)
         {
-            var rawContent = dataTypes.ReadNextString(data);
-            var hasFilteredContent = dataTypes.ReadNextBool(data);
+            var rawContent = DataTypes.ReadNextString(data);
+            var hasFilteredContent = DataTypes.ReadNextBool(data);
             var filteredContent = null as string;
             
             if(hasFilteredContent)
-                filteredContent = dataTypes.ReadNextString(data);
+                filteredContent = DataTypes.ReadNextString(data);
             
             Pages.Add(new BookPage(rawContent, hasFilteredContent, filteredContent));
         }

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/WrittenBlookContentComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/WrittenBlookContentComponent.cs
@@ -20,34 +20,34 @@ public class WrittenBlookContentComponent(DataTypes dataTypes, ItemPalette itemP
     
     public override void Parse(Queue<byte> data)
     {
-        RawTitle = dataTypes.ReadNextString(data);
-        HasFilteredTitle = dataTypes.ReadNextBool(data);
+        RawTitle = DataTypes.ReadNextString(data);
+        HasFilteredTitle = DataTypes.ReadNextBool(data);
 
         if (HasFilteredTitle)
-            FilteredTitle = dataTypes.ReadNextString(data);
+            FilteredTitle = DataTypes.ReadNextString(data);
         
-        Author = dataTypes.ReadNextString(data);
-        Generation = dataTypes.ReadNextVarInt(data);
-        NumberOfPages = dataTypes.ReadNextVarInt(data);
+        Author = DataTypes.ReadNextString(data);
+        Generation = DataTypes.ReadNextVarInt(data);
+        NumberOfPages = DataTypes.ReadNextVarInt(data);
 
         for (var i = 0; i < NumberOfPages; i++)
         {
-            var rawContentNbt = dataTypes.ReadNextNbt(data);
+            var rawContentNbt = DataTypes.ReadNextNbt(data);
             var rawContent = ChatParser.ParseText(rawContentNbt);
-            var hasFilteredContent = dataTypes.ReadNextBool(data);
+            var hasFilteredContent = DataTypes.ReadNextBool(data);
             Dictionary<string, object>? filteredContentNbt = null;
             string? filteredContent = null;
             
             if (hasFilteredContent)
             {
-                filteredContentNbt = dataTypes.ReadNextNbt(data);
+                filteredContentNbt = DataTypes.ReadNextNbt(data);
                 filteredContent = ChatParser.ParseText(filteredContentNbt);
             }
             
             Pages.Add(new BookPage(rawContent, hasFilteredContent, filteredContent, rawContentNbt, filteredContentNbt));
         }
 
-        Resolved = dataTypes.ReadNextBool(data);
+        Resolved = DataTypes.ReadNextBool(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21/JukeBoxPlayableComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21/JukeBoxPlayableComponent.cs
@@ -21,26 +21,26 @@ public class JukeBoxPlayableComponent(DataTypes dataTypes, ItemPalette itemPalet
     
     public override void Parse(Queue<byte> data)
     {
-        DirectMode = dataTypes.ReadNextBool(data);
+        DirectMode = DataTypes.ReadNextBool(data);
 
         if (!DirectMode)
-            SongName = dataTypes.ReadNextString(data);
+            SongName = DataTypes.ReadNextString(data);
 
         if (DirectMode)
         {
-            SongType = dataTypes.ReadNextVarInt(data);
+            SongType = DataTypes.ReadNextVarInt(data);
 
             if (SongType == 0)
             {
                 SoundEvent =
-                    (SoundEventSubComponent)subComponentRegistry.ParseSubComponent(SubComponents.SoundEvent, data);
-                Description = dataTypes.ReadNextString(data);
-                Duration = dataTypes.ReadNextFloat(data);
-                Output = dataTypes.ReadNextVarInt(data);
+                    (SoundEventSubComponent)SubComponentRegistry.ParseSubComponent(SubComponents.SoundEvent, data);
+                Description = DataTypes.ReadNextString(data);
+                Duration = DataTypes.ReadNextFloat(data);
+                Output = DataTypes.ReadNextVarInt(data);
             }
         }
 
-        ShowTooltip = dataTypes.ReadNextBool(data);
+        ShowTooltip = DataTypes.ReadNextBool(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_11/AttackRangeComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_11/AttackRangeComponent.cs
@@ -16,12 +16,12 @@ public class AttackRangeComponent(DataTypes dataTypes, ItemPalette itemPalette, 
 
     public override void Parse(Queue<byte> data)
     {
-        MinRange = dataTypes.ReadNextFloat(data);
-        MaxRange = dataTypes.ReadNextFloat(data);
-        MinCreativeRange = dataTypes.ReadNextFloat(data);
-        MaxCreativeRange = dataTypes.ReadNextFloat(data);
-        HitboxMargin = dataTypes.ReadNextFloat(data);
-        MobFactor = dataTypes.ReadNextFloat(data);
+        MinRange = DataTypes.ReadNextFloat(data);
+        MaxRange = DataTypes.ReadNextFloat(data);
+        MinCreativeRange = DataTypes.ReadNextFloat(data);
+        MaxCreativeRange = DataTypes.ReadNextFloat(data);
+        HitboxMargin = DataTypes.ReadNextFloat(data);
+        MobFactor = DataTypes.ReadNextFloat(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_11/KineticWeaponComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_11/KineticWeaponComponent.cs
@@ -9,34 +9,34 @@ public class KineticWeaponComponent(DataTypes dataTypes, ItemPalette itemPalette
 {
     public override void Parse(Queue<byte> data)
     {
-        dataTypes.ReadNextVarInt(data); // contactCooldownTicks
-        dataTypes.ReadNextVarInt(data); // delayTicks
+        DataTypes.ReadNextVarInt(data); // contactCooldownTicks
+        DataTypes.ReadNextVarInt(data); // delayTicks
         ReadOptionalCondition(data);    // dismountConditions
         ReadOptionalCondition(data);    // knockbackConditions
         ReadOptionalCondition(data);    // damageConditions
-        dataTypes.ReadNextFloat(data);  // forwardMovement
-        dataTypes.ReadNextFloat(data);  // damageMultiplier
+        DataTypes.ReadNextFloat(data);  // forwardMovement
+        DataTypes.ReadNextFloat(data);  // damageMultiplier
         ReadOptionalSoundEventHolder(data); // sound
         ReadOptionalSoundEventHolder(data); // hitSound
     }
 
     private void ReadOptionalCondition(Queue<byte> data)
     {
-        if (!dataTypes.ReadNextBool(data)) return;
-        dataTypes.ReadNextVarInt(data); // maxDurationTicks
-        dataTypes.ReadNextFloat(data);  // minSpeed
-        dataTypes.ReadNextFloat(data);  // minRelativeSpeed
+        if (!DataTypes.ReadNextBool(data)) return;
+        DataTypes.ReadNextVarInt(data); // maxDurationTicks
+        DataTypes.ReadNextFloat(data);  // minSpeed
+        DataTypes.ReadNextFloat(data);  // minRelativeSpeed
     }
 
     private void ReadOptionalSoundEventHolder(Queue<byte> data)
     {
-        if (!dataTypes.ReadNextBool(data)) return;
-        var holderId = dataTypes.ReadNextVarInt(data);
+        if (!DataTypes.ReadNextBool(data)) return;
+        var holderId = DataTypes.ReadNextVarInt(data);
         if (holderId == 0)
         {
-            dataTypes.ReadNextString(data);
-            if (dataTypes.ReadNextBool(data))
-                dataTypes.ReadNextFloat(data);
+            DataTypes.ReadNextString(data);
+            if (DataTypes.ReadNextBool(data))
+                DataTypes.ReadNextFloat(data);
         }
     }
 

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_11/PiercingWeaponComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_11/PiercingWeaponComponent.cs
@@ -12,21 +12,21 @@ public class PiercingWeaponComponent(DataTypes dataTypes, ItemPalette itemPalett
 
     public override void Parse(Queue<byte> data)
     {
-        DealsKnockback = dataTypes.ReadNextBool(data);
-        Dismounts = dataTypes.ReadNextBool(data);
+        DealsKnockback = DataTypes.ReadNextBool(data);
+        Dismounts = DataTypes.ReadNextBool(data);
         ReadOptionalSoundEventHolder(data);
         ReadOptionalSoundEventHolder(data);
     }
 
     private void ReadOptionalSoundEventHolder(Queue<byte> data)
     {
-        if (!dataTypes.ReadNextBool(data)) return;
-        var holderId = dataTypes.ReadNextVarInt(data);
+        if (!DataTypes.ReadNextBool(data)) return;
+        var holderId = DataTypes.ReadNextVarInt(data);
         if (holderId == 0)
         {
-            dataTypes.ReadNextString(data);
-            if (dataTypes.ReadNextBool(data))
-                dataTypes.ReadNextFloat(data);
+            DataTypes.ReadNextString(data);
+            if (DataTypes.ReadNextBool(data))
+                DataTypes.ReadNextFloat(data);
         }
     }
 

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_11/RegistryEitherHolderComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_11/RegistryEitherHolderComponent.cs
@@ -18,11 +18,11 @@ public class RegistryEitherHolderComponent(DataTypes dataTypes, ItemPalette item
 
     public override void Parse(Queue<byte> data)
     {
-        IsHolder = dataTypes.ReadNextBool(data);
+        IsHolder = DataTypes.ReadNextBool(data);
         if (IsHolder)
-            HolderId = dataTypes.ReadNextVarInt(data);
+            HolderId = DataTypes.ReadNextVarInt(data);
         else
-            ResourceKey = dataTypes.ReadNextString(data);
+            ResourceKey = DataTypes.ReadNextString(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_11/SwingAnimationComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_11/SwingAnimationComponent.cs
@@ -12,8 +12,8 @@ public class SwingAnimationComponent(DataTypes dataTypes, ItemPalette itemPalett
 
     public override void Parse(Queue<byte> data)
     {
-        AnimationType = dataTypes.ReadNextVarInt(data);
-        Duration = dataTypes.ReadNextVarInt(data);
+        AnimationType = DataTypes.ReadNextVarInt(data);
+        Duration = DataTypes.ReadNextVarInt(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_11/UseEffectsComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_11/UseEffectsComponent.cs
@@ -13,9 +13,9 @@ public class UseEffectsComponent(DataTypes dataTypes, ItemPalette itemPalette, S
 
     public override void Parse(Queue<byte> data)
     {
-        CanSprint = dataTypes.ReadNextBool(data);
-        InteractVibrations = dataTypes.ReadNextBool(data);
-        SpeedMultiplier = dataTypes.ReadNextFloat(data);
+        CanSprint = DataTypes.ReadNextBool(data);
+        InteractVibrations = DataTypes.ReadNextBool(data);
+        SpeedMultiplier = DataTypes.ReadNextFloat(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_2/ConsumableComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_2/ConsumableComponent.cs
@@ -17,15 +17,15 @@ public class ConsumableComponent(DataTypes dataTypes, ItemPalette itemPalette, S
 
     public override void Parse(Queue<byte> data)
     {
-        ConsumeSeconds = dataTypes.ReadNextFloat(data);
-        Animation = dataTypes.ReadNextVarInt(data);
-        Sound = (SoundEventSubComponent)subComponentRegistry.ParseSubComponent(SubComponents.SoundEvent, data);
-        HasConsumeParticles = dataTypes.ReadNextBool(data);
+        ConsumeSeconds = DataTypes.ReadNextFloat(data);
+        Animation = DataTypes.ReadNextVarInt(data);
+        Sound = (SoundEventSubComponent)SubComponentRegistry.ParseSubComponent(SubComponents.SoundEvent, data);
+        HasConsumeParticles = DataTypes.ReadNextBool(data);
 
-        var effectCount = dataTypes.ReadNextVarInt(data);
+        var effectCount = DataTypes.ReadNextVarInt(data);
         for (var i = 0; i < effectCount; i++)
         {
-            var effectTypeId = dataTypes.ReadNextVarInt(data);
+            var effectTypeId = DataTypes.ReadNextVarInt(data);
             var effectData = ReadConsumeEffectPayload(effectTypeId, data);
             Effects.Add(new ConsumeEffectData(effectTypeId, effectData));
         }
@@ -37,11 +37,11 @@ public class ConsumableComponent(DataTypes dataTypes, ItemPalette itemPalette, S
         switch (effectTypeId)
         {
             case 0: // apply_effects: List<MobEffectInstance> + probability(float)
-                var effectCount = dataTypes.ReadNextVarInt(data);
+                var effectCount = DataTypes.ReadNextVarInt(data);
                 payload.AddRange(DataTypes.GetVarInt(effectCount));
                 for (var i = 0; i < effectCount; i++)
                     payload.AddRange(ReadMobEffectInstance(data));
-                payload.AddRange(DataTypes.GetFloat(dataTypes.ReadNextFloat(data)));
+                payload.AddRange(DataTypes.GetFloat(DataTypes.ReadNextFloat(data)));
                 break;
             case 1: // remove_effects: HolderSet<MobEffect>
                 payload.AddRange(ReadHolderSet(data));
@@ -49,10 +49,10 @@ public class ConsumableComponent(DataTypes dataTypes, ItemPalette itemPalette, S
             case 2: // clear_all_effects: empty
                 break;
             case 3: // teleport_randomly: float diameter
-                payload.AddRange(DataTypes.GetFloat(dataTypes.ReadNextFloat(data)));
+                payload.AddRange(DataTypes.GetFloat(DataTypes.ReadNextFloat(data)));
                 break;
             case 4: // play_sound: Holder<SoundEvent>
-                var sound = (SoundEventSubComponent)subComponentRegistry.ParseSubComponent(SubComponents.SoundEvent, data);
+                var sound = (SoundEventSubComponent)SubComponentRegistry.ParseSubComponent(SubComponents.SoundEvent, data);
                 payload.AddRange(sound.Serialize());
                 break;
         }
@@ -62,7 +62,7 @@ public class ConsumableComponent(DataTypes dataTypes, ItemPalette itemPalette, S
     private byte[] ReadMobEffectInstance(Queue<byte> data)
     {
         var result = new List<byte>();
-        var effectId = dataTypes.ReadNextVarInt(data);
+        var effectId = DataTypes.ReadNextVarInt(data);
         result.AddRange(DataTypes.GetVarInt(effectId));
         result.AddRange(ReadMobEffectDetails(data));
         return result.ToArray();
@@ -71,17 +71,17 @@ public class ConsumableComponent(DataTypes dataTypes, ItemPalette itemPalette, S
     private byte[] ReadMobEffectDetails(Queue<byte> data)
     {
         var result = new List<byte>();
-        var amplifier = dataTypes.ReadNextVarInt(data);
+        var amplifier = DataTypes.ReadNextVarInt(data);
         result.AddRange(DataTypes.GetVarInt(amplifier));
-        var duration = dataTypes.ReadNextVarInt(data);
+        var duration = DataTypes.ReadNextVarInt(data);
         result.AddRange(DataTypes.GetVarInt(duration));
-        var ambient = dataTypes.ReadNextBool(data);
+        var ambient = DataTypes.ReadNextBool(data);
         result.AddRange(DataTypes.GetBool(ambient));
-        var showParticles = dataTypes.ReadNextBool(data);
+        var showParticles = DataTypes.ReadNextBool(data);
         result.AddRange(DataTypes.GetBool(showParticles));
-        var showIcon = dataTypes.ReadNextBool(data);
+        var showIcon = DataTypes.ReadNextBool(data);
         result.AddRange(DataTypes.GetBool(showIcon));
-        var hasHiddenEffect = dataTypes.ReadNextBool(data);
+        var hasHiddenEffect = DataTypes.ReadNextBool(data);
         result.AddRange(DataTypes.GetBool(hasHiddenEffect));
         if (hasHiddenEffect)
             result.AddRange(ReadMobEffectDetails(data));
@@ -91,18 +91,18 @@ public class ConsumableComponent(DataTypes dataTypes, ItemPalette itemPalette, S
     private byte[] ReadHolderSet(Queue<byte> data)
     {
         var result = new List<byte>();
-        var type = dataTypes.ReadNextVarInt(data);
+        var type = DataTypes.ReadNextVarInt(data);
         result.AddRange(DataTypes.GetVarInt(type));
         if (type == 0)
         {
-            var tagName = dataTypes.ReadNextString(data);
+            var tagName = DataTypes.ReadNextString(data);
             result.AddRange(DataTypes.GetString(tagName));
         }
         else
         {
             for (var i = 0; i < type - 1; i++)
             {
-                var id = dataTypes.ReadNextVarInt(data);
+                var id = DataTypes.ReadNextVarInt(data);
                 result.AddRange(DataTypes.GetVarInt(id));
             }
         }
@@ -114,7 +114,7 @@ public class ConsumableComponent(DataTypes dataTypes, ItemPalette itemPalette, S
         var data = new List<byte>();
         data.AddRange(DataTypes.GetFloat(ConsumeSeconds));
         data.AddRange(DataTypes.GetVarInt(Animation));
-        if (Sound != null) data.AddRange(Sound.Serialize());
+        if (Sound is not null) data.AddRange(Sound.Serialize());
         data.AddRange(DataTypes.GetBool(HasConsumeParticles));
         data.AddRange(DataTypes.GetVarInt(Effects.Count));
         foreach (var effect in Effects)

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_2/DamageResistantComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_2/DamageResistantComponent.cs
@@ -11,7 +11,7 @@ public class DamageResistantComponent(DataTypes dataTypes, ItemPalette itemPalet
 
     public override void Parse(Queue<byte> data)
     {
-        Types = dataTypes.ReadNextString(data);
+        Types = DataTypes.ReadNextString(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_2/DeathProtectionComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_2/DeathProtectionComponent.cs
@@ -13,10 +13,10 @@ public class DeathProtectionComponent(DataTypes dataTypes, ItemPalette itemPalet
 
     public override void Parse(Queue<byte> data)
     {
-        var effectCount = dataTypes.ReadNextVarInt(data);
+        var effectCount = DataTypes.ReadNextVarInt(data);
         for (var i = 0; i < effectCount; i++)
         {
-            var effectTypeId = dataTypes.ReadNextVarInt(data);
+            var effectTypeId = DataTypes.ReadNextVarInt(data);
             var effectData = ReadConsumeEffectPayload(effectTypeId, data);
             DeathEffects.Add(new ConsumeEffectData(effectTypeId, effectData));
         }
@@ -28,11 +28,11 @@ public class DeathProtectionComponent(DataTypes dataTypes, ItemPalette itemPalet
         switch (effectTypeId)
         {
             case 0: // apply_effects
-                var effectCount = dataTypes.ReadNextVarInt(data);
+                var effectCount = DataTypes.ReadNextVarInt(data);
                 payload.AddRange(DataTypes.GetVarInt(effectCount));
                 for (var i = 0; i < effectCount; i++)
                     payload.AddRange(ReadMobEffectInstance(data));
-                payload.AddRange(DataTypes.GetFloat(dataTypes.ReadNextFloat(data)));
+                payload.AddRange(DataTypes.GetFloat(DataTypes.ReadNextFloat(data)));
                 break;
             case 1: // remove_effects
                 payload.AddRange(ReadHolderSet(data));
@@ -40,10 +40,10 @@ public class DeathProtectionComponent(DataTypes dataTypes, ItemPalette itemPalet
             case 2: // clear_all_effects
                 break;
             case 3: // teleport_randomly
-                payload.AddRange(DataTypes.GetFloat(dataTypes.ReadNextFloat(data)));
+                payload.AddRange(DataTypes.GetFloat(DataTypes.ReadNextFloat(data)));
                 break;
             case 4: // play_sound
-                var sound = (SoundEventSubComponent)subComponentRegistry.ParseSubComponent(SubComponents.SoundEvent, data);
+                var sound = (SoundEventSubComponent)SubComponentRegistry.ParseSubComponent(SubComponents.SoundEvent, data);
                 payload.AddRange(sound.Serialize());
                 break;
         }
@@ -53,7 +53,7 @@ public class DeathProtectionComponent(DataTypes dataTypes, ItemPalette itemPalet
     private byte[] ReadMobEffectInstance(Queue<byte> data)
     {
         var result = new List<byte>();
-        result.AddRange(DataTypes.GetVarInt(dataTypes.ReadNextVarInt(data)));
+        result.AddRange(DataTypes.GetVarInt(DataTypes.ReadNextVarInt(data)));
         result.AddRange(ReadMobEffectDetails(data));
         return result.ToArray();
     }
@@ -61,12 +61,12 @@ public class DeathProtectionComponent(DataTypes dataTypes, ItemPalette itemPalet
     private byte[] ReadMobEffectDetails(Queue<byte> data)
     {
         var result = new List<byte>();
-        result.AddRange(DataTypes.GetVarInt(dataTypes.ReadNextVarInt(data)));
-        result.AddRange(DataTypes.GetVarInt(dataTypes.ReadNextVarInt(data)));
-        result.AddRange(DataTypes.GetBool(dataTypes.ReadNextBool(data)));
-        result.AddRange(DataTypes.GetBool(dataTypes.ReadNextBool(data)));
-        result.AddRange(DataTypes.GetBool(dataTypes.ReadNextBool(data)));
-        var hasHidden = dataTypes.ReadNextBool(data);
+        result.AddRange(DataTypes.GetVarInt(DataTypes.ReadNextVarInt(data)));
+        result.AddRange(DataTypes.GetVarInt(DataTypes.ReadNextVarInt(data)));
+        result.AddRange(DataTypes.GetBool(DataTypes.ReadNextBool(data)));
+        result.AddRange(DataTypes.GetBool(DataTypes.ReadNextBool(data)));
+        result.AddRange(DataTypes.GetBool(DataTypes.ReadNextBool(data)));
+        var hasHidden = DataTypes.ReadNextBool(data);
         result.AddRange(DataTypes.GetBool(hasHidden));
         if (hasHidden)
             result.AddRange(ReadMobEffectDetails(data));
@@ -76,16 +76,16 @@ public class DeathProtectionComponent(DataTypes dataTypes, ItemPalette itemPalet
     private byte[] ReadHolderSet(Queue<byte> data)
     {
         var result = new List<byte>();
-        var type = dataTypes.ReadNextVarInt(data);
+        var type = DataTypes.ReadNextVarInt(data);
         result.AddRange(DataTypes.GetVarInt(type));
         if (type == 0)
         {
-            result.AddRange(DataTypes.GetString(dataTypes.ReadNextString(data)));
+            result.AddRange(DataTypes.GetString(DataTypes.ReadNextString(data)));
         }
         else
         {
             for (var i = 0; i < type - 1; i++)
-                result.AddRange(DataTypes.GetVarInt(dataTypes.ReadNextVarInt(data)));
+                result.AddRange(DataTypes.GetVarInt(DataTypes.ReadNextVarInt(data)));
         }
         return result.ToArray();
     }

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_2/EnchantableComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_2/EnchantableComponent.cs
@@ -11,7 +11,7 @@ public class EnchantableComponent(DataTypes dataTypes, ItemPalette itemPalette, 
 
     public override void Parse(Queue<byte> data)
     {
-        Value = dataTypes.ReadNextVarInt(data);
+        Value = DataTypes.ReadNextVarInt(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_2/EquippableComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_2/EquippableComponent.cs
@@ -25,61 +25,61 @@ public class EquippableComponent(DataTypes dataTypes, ItemPalette itemPalette, S
 
     public override void Parse(Queue<byte> data)
     {
-        Slot = dataTypes.ReadNextVarInt(data);
-        EquipSound = (SoundEventSubComponent)subComponentRegistry.ParseSubComponent(SubComponents.SoundEvent, data);
+        Slot = DataTypes.ReadNextVarInt(data);
+        EquipSound = (SoundEventSubComponent)SubComponentRegistry.ParseSubComponent(SubComponents.SoundEvent, data);
         
-        HasModel = dataTypes.ReadNextBool(data);
+        HasModel = DataTypes.ReadNextBool(data);
         if (HasModel)
-            Model = dataTypes.ReadNextString(data);
+            Model = DataTypes.ReadNextString(data);
 
-        HasCameraOverlay = dataTypes.ReadNextBool(data);
+        HasCameraOverlay = DataTypes.ReadNextBool(data);
         if (HasCameraOverlay)
-            CameraOverlay = dataTypes.ReadNextString(data);
+            CameraOverlay = DataTypes.ReadNextString(data);
 
-        HasAllowedEntities = dataTypes.ReadNextBool(data);
+        HasAllowedEntities = DataTypes.ReadNextBool(data);
         if (HasAllowedEntities)
         {
-            AllowedEntitiesType = dataTypes.ReadNextVarInt(data);
+            AllowedEntitiesType = DataTypes.ReadNextVarInt(data);
             if (AllowedEntitiesType == 0)
             {
-                AllowedEntitiesTag = dataTypes.ReadNextString(data);
+                AllowedEntitiesTag = DataTypes.ReadNextString(data);
             }
             else
             {
                 AllowedEntitiesIds = new List<int>();
                 for (var i = 0; i < AllowedEntitiesType - 1; i++)
-                    AllowedEntitiesIds.Add(dataTypes.ReadNextVarInt(data));
+                    AllowedEntitiesIds.Add(DataTypes.ReadNextVarInt(data));
             }
         }
 
-        Dispensable = dataTypes.ReadNextBool(data);
-        Swappable = dataTypes.ReadNextBool(data);
-        DamageOnHurt = dataTypes.ReadNextBool(data);
+        Dispensable = DataTypes.ReadNextBool(data);
+        Swappable = DataTypes.ReadNextBool(data);
+        DamageOnHurt = DataTypes.ReadNextBool(data);
     }
 
     public override Queue<byte> Serialize()
     {
         var data = new List<byte>();
         data.AddRange(DataTypes.GetVarInt(Slot));
-        if (EquipSound != null) data.AddRange(EquipSound.Serialize());
+        if (EquipSound is not null) data.AddRange(EquipSound.Serialize());
 
         data.AddRange(DataTypes.GetBool(HasModel));
-        if (HasModel && Model != null)
+        if (HasModel && Model is not null)
             data.AddRange(DataTypes.GetString(Model));
 
         data.AddRange(DataTypes.GetBool(HasCameraOverlay));
-        if (HasCameraOverlay && CameraOverlay != null)
+        if (HasCameraOverlay && CameraOverlay is not null)
             data.AddRange(DataTypes.GetString(CameraOverlay));
 
         data.AddRange(DataTypes.GetBool(HasAllowedEntities));
         if (HasAllowedEntities)
         {
             data.AddRange(DataTypes.GetVarInt(AllowedEntitiesType));
-            if (AllowedEntitiesType == 0 && AllowedEntitiesTag != null)
+            if (AllowedEntitiesType == 0 && AllowedEntitiesTag is not null)
             {
                 data.AddRange(DataTypes.GetString(AllowedEntitiesTag));
             }
-            else if (AllowedEntitiesIds != null)
+            else if (AllowedEntitiesIds is not null)
             {
                 foreach (var id in AllowedEntitiesIds)
                     data.AddRange(DataTypes.GetVarInt(id));

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_2/FoodComponent1212.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_2/FoodComponent1212.cs
@@ -13,9 +13,9 @@ public class FoodComponent1212(DataTypes dataTypes, ItemPalette itemPalette, Sub
 
     public override void Parse(Queue<byte> data)
     {
-        Nutrition = dataTypes.ReadNextVarInt(data);
-        Saturation = dataTypes.ReadNextFloat(data);
-        CanAlwaysEat = dataTypes.ReadNextBool(data);
+        Nutrition = DataTypes.ReadNextVarInt(data);
+        Saturation = DataTypes.ReadNextFloat(data);
+        CanAlwaysEat = DataTypes.ReadNextBool(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_2/ItemModelComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_2/ItemModelComponent.cs
@@ -11,7 +11,7 @@ public class ItemModelComponent(DataTypes dataTypes, ItemPalette itemPalette, Su
 
     public override void Parse(Queue<byte> data)
     {
-        Identifier = dataTypes.ReadNextString(data);
+        Identifier = DataTypes.ReadNextString(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_2/RepairableComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_2/RepairableComponent.cs
@@ -13,16 +13,16 @@ public class RepairableComponent(DataTypes dataTypes, ItemPalette itemPalette, S
 
     public override void Parse(Queue<byte> data)
     {
-        Type = dataTypes.ReadNextVarInt(data);
+        Type = DataTypes.ReadNextVarInt(data);
         if (Type == 0)
         {
-            TagName = dataTypes.ReadNextString(data);
+            TagName = DataTypes.ReadNextString(data);
         }
         else
         {
             ItemIds = new List<int>();
             for (var i = 0; i < Type - 1; i++)
-                ItemIds.Add(dataTypes.ReadNextVarInt(data));
+                ItemIds.Add(DataTypes.ReadNextVarInt(data));
         }
     }
 
@@ -30,11 +30,11 @@ public class RepairableComponent(DataTypes dataTypes, ItemPalette itemPalette, S
     {
         var data = new List<byte>();
         data.AddRange(DataTypes.GetVarInt(Type));
-        if (Type == 0 && TagName != null)
+        if (Type == 0 && TagName is not null)
         {
             data.AddRange(DataTypes.GetString(TagName));
         }
-        else if (ItemIds != null)
+        else if (ItemIds is not null)
         {
             foreach (var id in ItemIds)
                 data.AddRange(DataTypes.GetVarInt(id));

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_2/TooltipStyleComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_2/TooltipStyleComponent.cs
@@ -11,7 +11,7 @@ public class TooltipStyleComponent(DataTypes dataTypes, ItemPalette itemPalette,
 
     public override void Parse(Queue<byte> data)
     {
-        Identifier = dataTypes.ReadNextString(data);
+        Identifier = DataTypes.ReadNextString(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_2/UseCooldownComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_2/UseCooldownComponent.cs
@@ -13,10 +13,10 @@ public class UseCooldownComponent(DataTypes dataTypes, ItemPalette itemPalette, 
 
     public override void Parse(Queue<byte> data)
     {
-        Seconds = dataTypes.ReadNextFloat(data);
-        HasCooldownGroup = dataTypes.ReadNextBool(data);
+        Seconds = DataTypes.ReadNextFloat(data);
+        HasCooldownGroup = DataTypes.ReadNextBool(data);
         if (HasCooldownGroup)
-            CooldownGroup = dataTypes.ReadNextString(data);
+            CooldownGroup = DataTypes.ReadNextString(data);
     }
 
     public override Queue<byte> Serialize()
@@ -24,7 +24,7 @@ public class UseCooldownComponent(DataTypes dataTypes, ItemPalette itemPalette, 
         var data = new List<byte>();
         data.AddRange(DataTypes.GetFloat(Seconds));
         data.AddRange(DataTypes.GetBool(HasCooldownGroup));
-        if (HasCooldownGroup && CooldownGroup != null)
+        if (HasCooldownGroup && CooldownGroup is not null)
             data.AddRange(DataTypes.GetString(CooldownGroup));
         return new Queue<byte>(data);
     }

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_2/UseRemainderComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_2/UseRemainderComponent.cs
@@ -12,13 +12,13 @@ public class UseRemainderComponent(DataTypes dataTypes, ItemPalette itemPalette,
 
     public override void Parse(Queue<byte> data)
     {
-        ConvertInto = dataTypes.ReadNextItemSlot(data, ItemPalette);
+        ConvertInto = DataTypes.ReadNextItemSlot(data, ItemPalette);
     }
 
     public override Queue<byte> Serialize()
     {
         var data = new List<byte>();
-        data.AddRange(dataTypes.GetItemSlot(ConvertInto, ItemPalette));
+        data.AddRange(DataTypes.GetItemSlot(ConvertInto, ItemPalette));
         return new Queue<byte>(data);
     }
 }

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_5/BlocksAttacksComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_5/BlocksAttacksComponent.cs
@@ -16,63 +16,63 @@ public class BlocksAttacksComponent(DataTypes dataTypes, ItemPalette itemPalette
 
     public override void Parse(Queue<byte> data)
     {
-        BlockDelaySeconds = dataTypes.ReadNextFloat(data);
-        DisableCooldownScale = dataTypes.ReadNextFloat(data);
+        BlockDelaySeconds = DataTypes.ReadNextFloat(data);
+        DisableCooldownScale = DataTypes.ReadNextFloat(data);
 
-        var reductionCount = dataTypes.ReadNextVarInt(data);
+        var reductionCount = DataTypes.ReadNextVarInt(data);
         for (var i = 0; i < reductionCount; i++)
         {
-            var horizontalBlockingAngle = dataTypes.ReadNextFloat(data);
+            var horizontalBlockingAngle = DataTypes.ReadNextFloat(data);
 
-            var hasTypeFilter = dataTypes.ReadNextBool(data);
+            var hasTypeFilter = DataTypes.ReadNextBool(data);
             if (hasTypeFilter)
                 ReadHolderSet(data);
 
-            var baseDmg = dataTypes.ReadNextFloat(data);
-            var factor = dataTypes.ReadNextFloat(data);
+            var baseDmg = DataTypes.ReadNextFloat(data);
+            var factor = DataTypes.ReadNextFloat(data);
         }
 
-        ItemDamageThreshold = dataTypes.ReadNextFloat(data);
-        ItemDamageBase = dataTypes.ReadNextFloat(data);
-        ItemDamageFactor = dataTypes.ReadNextFloat(data);
+        ItemDamageThreshold = DataTypes.ReadNextFloat(data);
+        ItemDamageBase = DataTypes.ReadNextFloat(data);
+        ItemDamageFactor = DataTypes.ReadNextFloat(data);
 
-        var hasBypassedBy = dataTypes.ReadNextBool(data);
+        var hasBypassedBy = DataTypes.ReadNextBool(data);
         if (hasBypassedBy)
-            dataTypes.ReadNextString(data); // TagKey<DamageType> as ResourceLocation
+            DataTypes.ReadNextString(data); // TagKey<DamageType> as ResourceLocation
 
-        var hasBlockSound = dataTypes.ReadNextBool(data);
+        var hasBlockSound = DataTypes.ReadNextBool(data);
         if (hasBlockSound)
             ReadSoundEventHolder(data);
 
-        var hasDisableSound = dataTypes.ReadNextBool(data);
+        var hasDisableSound = DataTypes.ReadNextBool(data);
         if (hasDisableSound)
             ReadSoundEventHolder(data);
     }
 
     private void ReadHolderSet(Queue<byte> data)
     {
-        var sizeOrTag = dataTypes.ReadNextVarInt(data);
+        var sizeOrTag = DataTypes.ReadNextVarInt(data);
         if (sizeOrTag == 0)
         {
-            dataTypes.ReadNextString(data); // Tag ResourceLocation
+            DataTypes.ReadNextString(data); // Tag ResourceLocation
         }
         else
         {
             var count = sizeOrTag - 1;
             for (var i = 0; i < count; i++)
-                dataTypes.ReadNextVarInt(data); // Holder<DamageType> registry ids
+                DataTypes.ReadNextVarInt(data); // Holder<DamageType> registry ids
         }
     }
 
     private void ReadSoundEventHolder(Queue<byte> data)
     {
-        var holderId = dataTypes.ReadNextVarInt(data);
+        var holderId = DataTypes.ReadNextVarInt(data);
         if (holderId == 0)
         {
-            dataTypes.ReadNextString(data); // ResourceLocation
-            var hasFixedRange = dataTypes.ReadNextBool(data);
+            DataTypes.ReadNextString(data); // ResourceLocation
+            var hasFixedRange = DataTypes.ReadNextBool(data);
             if (hasFixedRange)
-                dataTypes.ReadNextFloat(data);
+                DataTypes.ReadNextFloat(data);
         }
     }
 

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_5/EitherHolderComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_5/EitherHolderComponent.cs
@@ -13,10 +13,10 @@ public class EitherHolderComponent(DataTypes dataTypes, ItemPalette itemPalette,
 
     public override void Parse(Queue<byte> data)
     {
-        IsHolder = dataTypes.ReadNextBool(data);
+        IsHolder = DataTypes.ReadNextBool(data);
         if (IsHolder)
         {
-            HolderId = dataTypes.ReadNextVarInt(data);
+            HolderId = DataTypes.ReadNextVarInt(data);
             // For simple entity variants, holderId > 0 means registry ref (id = holderId - 1)
             // holderId == 0 means inline data; for most variants the inline is just the variant fields
             // We skip inline data since MCC doesn't use variant details
@@ -30,7 +30,7 @@ public class EitherHolderComponent(DataTypes dataTypes, ItemPalette itemPalette,
         }
         else
         {
-            ResourceKey = dataTypes.ReadNextString(data);
+            ResourceKey = DataTypes.ReadNextString(data);
         }
     }
 

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_5/EnchantmentsComponent1215.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_5/EnchantmentsComponent1215.cs
@@ -15,12 +15,12 @@ public class EnchantmentsComponent1215(DataTypes dataTypes, ItemPalette itemPale
 {
     public override void Parse(Queue<byte> data)
     {
-        NumberOfEnchantments = dataTypes.ReadNextVarInt(data);
+        NumberOfEnchantments = DataTypes.ReadNextVarInt(data);
 
         for (var i = 0; i < NumberOfEnchantments; i++)
         {
-            var registryId = dataTypes.ReadNextVarInt(data);
-            var level = dataTypes.ReadNextVarInt(data);
+            var registryId = DataTypes.ReadNextVarInt(data);
+            var level = DataTypes.ReadNextVarInt(data);
             Enchantments.Add(new Enchantment(EnchantmentMapping.GetEnchantmentByRegistryId1206(registryId), level));
         }
     }

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_5/InstrumentComponent1215.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_5/InstrumentComponent1215.cs
@@ -10,29 +10,29 @@ public class InstrumentComponent1215(DataTypes dataTypes, ItemPalette itemPalett
     public override void Parse(Queue<byte> data)
     {
         // EitherHolder<Instrument>: Bool + (Holder<Instrument> OR ResourceLocation)
-        var isHolder = dataTypes.ReadNextBool(data);
+        var isHolder = DataTypes.ReadNextBool(data);
         if (isHolder)
         {
-            var holderId = dataTypes.ReadNextVarInt(data);
+            var holderId = DataTypes.ReadNextVarInt(data);
             if (holderId == 0)
             {
                 // Inline Instrument: SoundEvent holder + VarInt useDuration + Float range + Component description
-                var soundHolderId = dataTypes.ReadNextVarInt(data);
+                var soundHolderId = DataTypes.ReadNextVarInt(data);
                 if (soundHolderId == 0)
                 {
-                    dataTypes.ReadNextString(data); // ResourceLocation
-                    var hasFixedRange = dataTypes.ReadNextBool(data);
+                    DataTypes.ReadNextString(data); // ResourceLocation
+                    var hasFixedRange = DataTypes.ReadNextBool(data);
                     if (hasFixedRange)
-                        dataTypes.ReadNextFloat(data);
+                        DataTypes.ReadNextFloat(data);
                 }
-                dataTypes.ReadNextVarInt(data); // useDuration
-                dataTypes.ReadNextFloat(data); // range
-                dataTypes.ReadNextString(data); // description (Component as JSON string)
+                DataTypes.ReadNextVarInt(data); // useDuration
+                DataTypes.ReadNextFloat(data); // range
+                DataTypes.ReadNextString(data); // description (Component as JSON string)
             }
         }
         else
         {
-            dataTypes.ReadNextString(data); // ResourceLocation key
+            DataTypes.ReadNextString(data); // ResourceLocation key
         }
     }
 

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_5/PaintingVariantHolderComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_5/PaintingVariantHolderComponent.cs
@@ -10,21 +10,21 @@ public class PaintingVariantHolderComponent(DataTypes dataTypes, ItemPalette ite
     public override void Parse(Queue<byte> data)
     {
         // Holder<PaintingVariant>: VarInt discriminator
-        var holderId = dataTypes.ReadNextVarInt(data);
+        var holderId = DataTypes.ReadNextVarInt(data);
         if (holderId == 0)
         {
             // Inline PaintingVariant: VarInt width + VarInt height + ResourceLocation assetId
-            dataTypes.ReadNextVarInt(data); // width
-            dataTypes.ReadNextVarInt(data); // height
-            dataTypes.ReadNextString(data); // assetId
+            DataTypes.ReadNextVarInt(data); // width
+            DataTypes.ReadNextVarInt(data); // height
+            DataTypes.ReadNextString(data); // assetId
 
             // Optional<Component> title
-            if (dataTypes.ReadNextBool(data))
-                dataTypes.ReadNextString(data);
+            if (DataTypes.ReadNextBool(data))
+                DataTypes.ReadNextString(data);
 
             // Optional<Component> author
-            if (dataTypes.ReadNextBool(data))
-                dataTypes.ReadNextString(data);
+            if (DataTypes.ReadNextBool(data))
+                DataTypes.ReadNextString(data);
         }
     }
 

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_5/PotionDurationScaleComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_5/PotionDurationScaleComponent.cs
@@ -11,7 +11,7 @@ public class PotionDurationScaleComponent(DataTypes dataTypes, ItemPalette itemP
 
     public override void Parse(Queue<byte> data)
     {
-        Scale = dataTypes.ReadNextFloat(data);
+        Scale = DataTypes.ReadNextFloat(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_5/ProvidesBannerPatternsComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_5/ProvidesBannerPatternsComponent.cs
@@ -11,7 +11,7 @@ public class ProvidesBannerPatternsComponent(DataTypes dataTypes, ItemPalette it
 
     public override void Parse(Queue<byte> data)
     {
-        TagKey = dataTypes.ReadNextString(data); // ResourceLocation
+        TagKey = DataTypes.ReadNextString(data); // ResourceLocation
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_5/ProvidesTrimMaterialComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_5/ProvidesTrimMaterialComponent.cs
@@ -10,28 +10,28 @@ public class ProvidesTrimMaterialComponent(DataTypes dataTypes, ItemPalette item
     public override void Parse(Queue<byte> data)
     {
         // EitherHolder<TrimMaterial>: Bool + (Holder<TrimMaterial> OR ResourceLocation)
-        var isHolder = dataTypes.ReadNextBool(data);
+        var isHolder = DataTypes.ReadNextBool(data);
         if (isHolder)
         {
-            var holderId = dataTypes.ReadNextVarInt(data);
+            var holderId = DataTypes.ReadNextVarInt(data);
             if (holderId == 0)
             {
                 // Inline TrimMaterial: MaterialAssetGroup + Component description
                 // MaterialAssetGroup: string + map<ResourceLocation, string>
-                dataTypes.ReadNextString(data); // base asset suffix
-                var overrideCount = dataTypes.ReadNextVarInt(data);
+                DataTypes.ReadNextString(data); // base asset suffix
+                var overrideCount = DataTypes.ReadNextVarInt(data);
                 for (var i = 0; i < overrideCount; i++)
                 {
-                    dataTypes.ReadNextString(data); // ResourceKey<EquipmentAsset>
-                    dataTypes.ReadNextString(data); // override suffix
+                    DataTypes.ReadNextString(data); // ResourceKey<EquipmentAsset>
+                    DataTypes.ReadNextString(data); // override suffix
                 }
                 // description Component
-                dataTypes.ReadNextString(data);
+                DataTypes.ReadNextString(data);
             }
         }
         else
         {
-            dataTypes.ReadNextString(data); // ResourceLocation key
+            DataTypes.ReadNextString(data); // ResourceLocation key
         }
     }
 

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_5/SoundEventHolderComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_5/SoundEventHolderComponent.cs
@@ -14,13 +14,13 @@ public class SoundEventHolderComponent(DataTypes dataTypes, ItemPalette itemPale
 
     public override void Parse(Queue<byte> data)
     {
-        HolderId = dataTypes.ReadNextVarInt(data);
+        HolderId = DataTypes.ReadNextVarInt(data);
         if (HolderId == 0)
         {
-            SoundLocation = dataTypes.ReadNextString(data);
-            HasFixedRange = dataTypes.ReadNextBool(data);
+            SoundLocation = DataTypes.ReadNextString(data);
+            HasFixedRange = DataTypes.ReadNextBool(data);
             if (HasFixedRange)
-                FixedRange = dataTypes.ReadNextFloat(data);
+                FixedRange = DataTypes.ReadNextFloat(data);
         }
     }
 

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_5/TooltipDisplayComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_5/TooltipDisplayComponent.cs
@@ -12,10 +12,10 @@ public class TooltipDisplayComponent(DataTypes dataTypes, ItemPalette itemPalett
 
     public override void Parse(Queue<byte> data)
     {
-        HideTooltip = dataTypes.ReadNextBool(data);
-        var count = dataTypes.ReadNextVarInt(data);
+        HideTooltip = DataTypes.ReadNextBool(data);
+        var count = DataTypes.ReadNextVarInt(data);
         for (var i = 0; i < count; i++)
-            HiddenComponentIds.Add(dataTypes.ReadNextVarInt(data));
+            HiddenComponentIds.Add(DataTypes.ReadNextVarInt(data));
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_5/VarIntComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_5/VarIntComponent.cs
@@ -11,7 +11,7 @@ public class VarIntComponent(DataTypes dataTypes, ItemPalette itemPalette, SubCo
 
     public override void Parse(Queue<byte> data)
     {
-        Value = dataTypes.ReadNextVarInt(data);
+        Value = DataTypes.ReadNextVarInt(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_5/WeaponComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_21_5/WeaponComponent.cs
@@ -12,8 +12,8 @@ public class WeaponComponent(DataTypes dataTypes, ItemPalette itemPalette, SubCo
 
     public override void Parse(Queue<byte> data)
     {
-        ItemDamagePerAttack = dataTypes.ReadNextVarInt(data);
-        DisableBlockingForSeconds = dataTypes.ReadNextFloat(data);
+        ItemDamagePerAttack = DataTypes.ReadNextVarInt(data);
+        DisableBlockingForSeconds = DataTypes.ReadNextFloat(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/Subcomponents/1_20_6/AttributeSubComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/Subcomponents/1_20_6/AttributeSubComponent.cs
@@ -15,12 +15,12 @@ public class AttributeSubComponent(DataTypes dataTypes, SubComponentRegistry sub
     
     protected override void Parse(Queue<byte> data)
     {
-        TypeId = dataTypes.ReadNextVarInt(data);
-        Uuid = dataTypes.ReadNextUUID(data);
-        Name = dataTypes.ReadNextString(data);
-        Value = dataTypes.ReadNextDouble(data);
-        Operation = dataTypes.ReadNextVarInt(data);
-        Slot = dataTypes.ReadNextVarInt(data);
+        TypeId = DataTypes.ReadNextVarInt(data);
+        Uuid = DataTypes.ReadNextUUID(data);
+        Name = DataTypes.ReadNextString(data);
+        Value = DataTypes.ReadNextDouble(data);
+        Operation = DataTypes.ReadNextVarInt(data);
+        Slot = DataTypes.ReadNextVarInt(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/Subcomponents/1_20_6/BlockPredicateSubcomponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/Subcomponents/1_20_6/BlockPredicateSubcomponent.cs
@@ -15,25 +15,25 @@ public class BlockPredicateSubcomponent(DataTypes dataTypes, SubComponentRegistr
         
     protected override void Parse(Queue<byte> data)
     {
-        HasBlocks = dataTypes.ReadNextBool(data);
+        HasBlocks = DataTypes.ReadNextBool(data);
 
         if (HasBlocks)
-            BlockSet = (BlockSetSubcomponent)subComponentRegistry.ParseSubComponent(SubComponents.BlockSet, data);
+            BlockSet = (BlockSetSubcomponent)SubComponentRegistry.ParseSubComponent(SubComponents.BlockSet, data);
 
-        HasProperities = dataTypes.ReadNextBool(data);
+        HasProperities = DataTypes.ReadNextBool(data);
 
         if (HasProperities)
         {
             Properties = new();
-            var numberOfProperties = dataTypes.ReadNextVarInt(data);
+            var numberOfProperties = DataTypes.ReadNextVarInt(data);
             for (var i = 0; i < numberOfProperties; i++)
-                Properties.Add((PropertySubComponent)subComponentRegistry.ParseSubComponent(SubComponents.Property, data));
+                Properties.Add((PropertySubComponent)SubComponentRegistry.ParseSubComponent(SubComponents.Property, data));
         }
 
-        HasNbt = dataTypes.ReadNextBool(data);
+        HasNbt = DataTypes.ReadNextBool(data);
         
         if (HasNbt)
-            Nbt = dataTypes.ReadNextNbt(data);
+            Nbt = DataTypes.ReadNextNbt(data);
     }
 
     public override Queue<byte> Serialize()
@@ -44,7 +44,7 @@ public class BlockPredicateSubcomponent(DataTypes dataTypes, SubComponentRegistr
         data.AddRange(DataTypes.GetBool(HasBlocks));
         if (HasBlocks)
         {
-            if(BlockSet == null)
+            if(BlockSet is null)
                 throw new ArgumentNullException($"Can not serialize a BlockPredicate when the BlockSet is empty but HasBlocks is true!");
             
             data.AddRange(BlockSet.Serialize());
@@ -54,7 +54,7 @@ public class BlockPredicateSubcomponent(DataTypes dataTypes, SubComponentRegistr
         data.AddRange(DataTypes.GetBool(HasProperities));
         if (HasProperities)
         {
-            if(Properties == null || Properties.Count == 0)
+            if(Properties is null || Properties.Count == 0)
                 throw new ArgumentNullException($"Can not serialize a BlockPredicate when the Properties is empty but HasProperties is true!");
 
             data.AddRange(DataTypes.GetVarInt(Properties.Count));
@@ -66,7 +66,7 @@ public class BlockPredicateSubcomponent(DataTypes dataTypes, SubComponentRegistr
         data.AddRange(DataTypes.GetBool(HasNbt));
         if (HasNbt)
         {
-            if(Nbt == null)
+            if(Nbt is null)
                 throw new ArgumentNullException($"Can not serialize a BlockPredicate when the Nbt is empty but HasNbt is true!");
             
             data.AddRange(DataTypes.GetNbt(Nbt));

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/Subcomponents/1_20_6/BlockSetSubcomponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/Subcomponents/1_20_6/BlockSetSubcomponent.cs
@@ -15,14 +15,14 @@ public class BlockSetSubcomponent(DataTypes dataTypes, SubComponentRegistry subC
         Type = DataTypes.ReadNextVarInt(data);
 
         if (Type == 0)
-            TagName = dataTypes.ReadNextString(data);
+            TagName = DataTypes.ReadNextString(data);
 
         if (Type == 0) return;
         
         BlockIds = [];
             
         for (var i = 0; i < Type - 1; i++)
-            BlockIds.Add(dataTypes.ReadNextVarInt(data));
+            BlockIds.Add(DataTypes.ReadNextVarInt(data));
     }
 
     public override Queue<byte> Serialize()
@@ -39,7 +39,7 @@ public class BlockSetSubcomponent(DataTypes dataTypes, SubComponentRegistry subC
 
         if (Type == 0) return new Queue<byte>(data);
         
-        if(BlockIds == null || BlockIds.Count == 0)
+        if(BlockIds is null || BlockIds.Count == 0)
             throw new ArgumentNullException($"Can not serialize an empty list of Block IDs in a Block Set when the type is not 0!");
             
         for(var i = 0; i < Type - 1; i++)

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/Subcomponents/1_20_6/DetailsSubComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/Subcomponents/1_20_6/DetailsSubComponent.cs
@@ -16,15 +16,15 @@ public class DetailsSubComponent(DataTypes dataTypes, SubComponentRegistry subCo
     
     protected override void Parse(Queue<byte> data)
     {
-        Amplifier = dataTypes.ReadNextVarInt(data);
-        Duration = dataTypes.ReadNextVarInt(data);
-        Ambient = dataTypes.ReadNextBool(data);
-        ShowParticles = dataTypes.ReadNextBool(data);
-        ShowIcon = dataTypes.ReadNextBool(data);
-        HasHiddenEffects = dataTypes.ReadNextBool(data);
+        Amplifier = DataTypes.ReadNextVarInt(data);
+        Duration = DataTypes.ReadNextVarInt(data);
+        Ambient = DataTypes.ReadNextBool(data);
+        ShowParticles = DataTypes.ReadNextBool(data);
+        ShowIcon = DataTypes.ReadNextBool(data);
+        HasHiddenEffects = DataTypes.ReadNextBool(data);
         
         if(HasHiddenEffects)
-            Detail = (DetailsSubComponent)subComponentRegistry.ParseSubComponent(SubComponents.Details, data);
+            Detail = (DetailsSubComponent)SubComponentRegistry.ParseSubComponent(SubComponents.Details, data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/Subcomponents/1_20_6/EffectSubComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/Subcomponents/1_20_6/EffectSubComponent.cs
@@ -6,13 +6,13 @@ namespace MinecraftClient.Protocol.Handlers.StructuredComponents.Components.Subc
 
 public class EffectSubComponent(DataTypes dataTypes, SubComponentRegistry subComponentRegistry) : SubComponent(dataTypes, subComponentRegistry)
 {
-    public PotionEffectSubComponent TypeId { get; set; }
+    public PotionEffectSubComponent TypeId { get; set; } = null!;
     public float Probability { get; set; }
     
     protected override void Parse(Queue<byte> data)
     {
-        TypeId = (PotionEffectSubComponent)subComponentRegistry.ParseSubComponent(SubComponents.PotionEffect, data);
-        Probability = dataTypes.ReadNextFloat(data);
+        TypeId = (PotionEffectSubComponent)SubComponentRegistry.ParseSubComponent(SubComponents.PotionEffect, data);
+        Probability = DataTypes.ReadNextFloat(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/Subcomponents/1_20_6/FireworkExplosionSubComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/Subcomponents/1_20_6/FireworkExplosionSubComponent.cs
@@ -16,19 +16,19 @@ public class FireworkExplosionSubComponent(DataTypes dataTypes, SubComponentRegi
     
     protected override void Parse(Queue<byte> data)
     {
-        Shape = dataTypes.ReadNextVarInt(data);
-        NumberOfColors = dataTypes.ReadNextVarInt(data);
+        Shape = DataTypes.ReadNextVarInt(data);
+        NumberOfColors = DataTypes.ReadNextVarInt(data);
 
         for (var i = 0; i < NumberOfColors; i++)
-            Colors.Add(dataTypes.ReadNextInt(data));
+            Colors.Add(DataTypes.ReadNextInt(data));
         
-        NumberOfFadeColors = dataTypes.ReadNextVarInt(data);
+        NumberOfFadeColors = DataTypes.ReadNextVarInt(data);
 
         for (var i = 0; i < NumberOfFadeColors; i++)
-            FadeColors.Add(dataTypes.ReadNextInt(data));
+            FadeColors.Add(DataTypes.ReadNextInt(data));
         
-        HasTrail = dataTypes.ReadNextBool(data);
-        HasTwinkle = dataTypes.ReadNextBool(data);
+        HasTrail = DataTypes.ReadNextBool(data);
+        HasTwinkle = DataTypes.ReadNextBool(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/Subcomponents/1_20_6/PotionEffectSubComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/Subcomponents/1_20_6/PotionEffectSubComponent.cs
@@ -7,12 +7,12 @@ namespace MinecraftClient.Protocol.Handlers.StructuredComponents.Components.Subc
 public class PotionEffectSubComponent(DataTypes dataTypes, SubComponentRegistry subComponentRegistry) : SubComponent(dataTypes, subComponentRegistry)
 {
     public int TypeId { get; set; }
-    public DetailsSubComponent Details { get; set; }
+    public DetailsSubComponent Details { get; set; } = null!;
     
     protected override void Parse(Queue<byte> data)
     {
-        TypeId = dataTypes.ReadNextVarInt(data);
-        Details = (DetailsSubComponent)subComponentRegistry.ParseSubComponent(SubComponents.Details, data);
+        TypeId = DataTypes.ReadNextVarInt(data);
+        Details = (DetailsSubComponent)SubComponentRegistry.ParseSubComponent(SubComponents.Details, data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/Subcomponents/1_20_6/PropertySubComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/Subcomponents/1_20_6/PropertySubComponent.cs
@@ -14,17 +14,17 @@ public class PropertySubComponent(DataTypes dataTypes, SubComponentRegistry subC
     
     protected override void Parse(Queue<byte> data)
     {
-        Name = dataTypes.ReadNextString(data);
-        IsExactMatch = dataTypes.ReadNextBool(data);
+        Name = DataTypes.ReadNextString(data);
+        IsExactMatch = DataTypes.ReadNextBool(data);
 
         if (IsExactMatch)
         {
-            ExactValue = dataTypes.ReadNextString(data);
+            ExactValue = DataTypes.ReadNextString(data);
         }
         else
         {
-            MinValue = dataTypes.ReadNextBool(data) ? dataTypes.ReadNextString(data) : null;
-            MaxValue = dataTypes.ReadNextBool(data) ? dataTypes.ReadNextString(data) : null;
+            MinValue = DataTypes.ReadNextBool(data) ? DataTypes.ReadNextString(data) : null;
+            MaxValue = DataTypes.ReadNextBool(data) ? DataTypes.ReadNextString(data) : null;
         }
     }
 
@@ -47,12 +47,12 @@ public class PropertySubComponent(DataTypes dataTypes, SubComponentRegistry subC
         }
         else
         {
-            data.AddRange(DataTypes.GetBool(MinValue != null));
-            if (MinValue != null)
+            data.AddRange(DataTypes.GetBool(MinValue is not null));
+            if (MinValue is not null)
                 data.AddRange(DataTypes.GetString(MinValue));
             
-            data.AddRange(DataTypes.GetBool(MaxValue != null));
-            if (MaxValue != null)
+            data.AddRange(DataTypes.GetBool(MaxValue is not null));
+            if (MaxValue is not null)
                 data.AddRange(DataTypes.GetString(MaxValue));
         }
         

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/Subcomponents/1_20_6/RuleSubComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/Subcomponents/1_20_6/RuleSubComponent.cs
@@ -6,7 +6,7 @@ namespace MinecraftClient.Protocol.Handlers.StructuredComponents.Components.Subc
 
 public class RuleSubComponent(DataTypes dataTypes, SubComponentRegistry subComponentRegistry) : SubComponent(dataTypes, subComponentRegistry)
 {
-    public BlockSetSubcomponent Blocks { get; set; }
+    public BlockSetSubcomponent Blocks { get; set; } = null!;
     public bool HasSpeed { get; set; }
     public float Speed { get; set; }
     public bool HasCorrectDropForBlocks { get; set; }
@@ -14,16 +14,16 @@ public class RuleSubComponent(DataTypes dataTypes, SubComponentRegistry subCompo
     
     protected override void Parse(Queue<byte> data)
     {
-        Blocks = (BlockSetSubcomponent)subComponentRegistry.ParseSubComponent(SubComponents.BlockSet, data);
-        HasSpeed = dataTypes.ReadNextBool(data);
+        Blocks = (BlockSetSubcomponent)SubComponentRegistry.ParseSubComponent(SubComponents.BlockSet, data);
+        HasSpeed = DataTypes.ReadNextBool(data);
         
         if(HasSpeed)
-            Speed = dataTypes.ReadNextFloat(data);
+            Speed = DataTypes.ReadNextFloat(data);
         
-        HasCorrectDropForBlocks = dataTypes.ReadNextBool(data);
+        HasCorrectDropForBlocks = DataTypes.ReadNextBool(data);
         
         if(HasCorrectDropForBlocks)
-            CorrectDropForBlocks = dataTypes.ReadNextBool(data);
+            CorrectDropForBlocks = DataTypes.ReadNextBool(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/Subcomponents/1_21/AttributeSubComponent121.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/Subcomponents/1_21/AttributeSubComponent121.cs
@@ -14,11 +14,11 @@ public class AttributeSubComponent121(DataTypes dataTypes, SubComponentRegistry 
     
     protected override void Parse(Queue<byte> data)
     {
-        TypeId = dataTypes.ReadNextVarInt(data);
-        ResourceLocation = dataTypes.ReadNextString(data);
-        Value = dataTypes.ReadNextDouble(data);
-        Operation = dataTypes.ReadNextVarInt(data);
-        Slot = dataTypes.ReadNextVarInt(data);
+        TypeId = DataTypes.ReadNextVarInt(data);
+        ResourceLocation = DataTypes.ReadNextString(data);
+        Value = DataTypes.ReadNextDouble(data);
+        Operation = DataTypes.ReadNextVarInt(data);
+        Slot = DataTypes.ReadNextVarInt(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/Subcomponents/1_21/SoundEventSubComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/Subcomponents/1_21/SoundEventSubComponent.cs
@@ -13,15 +13,15 @@ public class SoundEventSubComponent(DataTypes dataTypes, SubComponentRegistry su
     
     protected override void Parse(Queue<byte> data)
     {
-        Type = dataTypes.ReadNextVarInt(data);
+        Type = DataTypes.ReadNextVarInt(data);
 
         if (Type != 0) return;
         
-        SoundName = dataTypes.ReadNextString(data);
-        HasFixedRange = dataTypes.ReadNextBool(data);
+        SoundName = DataTypes.ReadNextString(data);
+        HasFixedRange = DataTypes.ReadNextBool(data);
 
         if (HasFixedRange)
-            FixedRange = dataTypes.ReadNextFloat(data);
+            FixedRange = DataTypes.ReadNextFloat(data);
     }
 
     public override Queue<byte> Serialize()

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Core/SubComponentRegistry.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Core/SubComponentRegistry.cs
@@ -31,7 +31,7 @@ public abstract class SubComponentRegistry(DataTypes dataTypes)
         
         var parseMethod = instance.GetType().GetMethod("Parse", BindingFlags.Instance | BindingFlags.NonPublic);
         
-        if (parseMethod == null)
+        if (parseMethod is null)
             throw new InvalidOperationException($"Sub component parser type {subComponentParserType.Name} does not have a Parse method.");
         
         parseMethod.Invoke(instance, new object[] { data });

--- a/MinecraftClient/Protocol/Message/ChatMessage.cs
+++ b/MinecraftClient/Protocol/Message/ChatMessage.cs
@@ -64,7 +64,7 @@ namespace MinecraftClient.Protocol.Message
 
         public LastSeenMessageList.AcknowledgedMessage? ToLastSeenMessageEntry()
         {
-            return signature != null ? new LastSeenMessageList.AcknowledgedMessage(senderUUID, signature, true) : null;
+            return signature is not null ? new LastSeenMessageList.AcknowledgedMessage(senderUUID, signature, true) : null;
         }
 
         public bool LacksSender()

--- a/MinecraftClient/Protocol/Message/ChatParser.cs
+++ b/MinecraftClient/Protocol/Message/ChatParser.cs
@@ -123,7 +123,7 @@ namespace MinecraftClient.Protocol.Message
         {
             string sender = message.isSenderJson ? ParseText(message.displayName!) : message.displayName!;
             string content;
-            if (Config.Signature.ShowModifiedChat && message.unsignedContent != null)
+            if (Config.Signature.ShowModifiedChat && message.unsignedContent is not null)
             {
                 content = ParseText(message.unsignedContent!);
                 if (string.IsNullOrEmpty(content))
@@ -315,7 +315,7 @@ namespace MinecraftClient.Protocol.Message
                     Task<Dictionary<string, string>?> fetckFileTask =
                         httpClient.GetFromJsonAsync<Dictionary<string, string>>(translation_file_location);
                     fetckFileTask.Wait();
-                    if (fetckFileTask.Result != null && fetckFileTask.Result.Count > 0)
+                    if (fetckFileTask.Result is not null && fetckFileTask.Result.Count > 0)
                     {
                         TranslationRules = fetckFileTask.Result;
                         TranslationRules["Version"] = TranslationsFile_Version;
@@ -511,7 +511,7 @@ namespace MinecraftClient.Protocol.Message
 
             string message = string.Empty;
             string colorCode = string.Empty;
-            StringBuilder extraBuilder = new StringBuilder();
+            StringBuilder extraBuilder = new();
             foreach (var kvp in nbt)
             {
                 string key = kvp.Key;
@@ -545,11 +545,11 @@ namespace MinecraftClient.Protocol.Message
                         break;
                     case "translate":
                     {
-                        if (nbt.TryGetValue("translate", out object translate))
+                        if (nbt.TryGetValue("translate", out object? translate))
                         {
                             var translateKey = (string)translate;
                             List<string> translateString = new();
-                            if (nbt.TryGetValue("with", out object withComponent))
+                            if (nbt.TryGetValue("with", out object? withComponent))
                             {
                                 var withs = (object[])withComponent;
                                 for (var i = 0; i < withs.Length; i++)
@@ -574,7 +574,7 @@ namespace MinecraftClient.Protocol.Message
                         break;
                     case "color":
                     {
-                        if (nbt.TryGetValue("color", out object color))
+                        if (nbt.TryGetValue("color", out object? color))
                         {
                             colorCode = Color2tag((string)color);
                         }

--- a/MinecraftClient/Protocol/Message/LastSeenMessageList.cs
+++ b/MinecraftClient/Protocol/Message/LastSeenMessageList.cs
@@ -8,17 +8,12 @@ namespace MinecraftClient.Protocol.Message
     /// <summary>
     /// A list of messages a client has seen.
     /// </summary>
-    public class LastSeenMessageList
+    public class LastSeenMessageList(AcknowledgedMessage[] list)
     {
         public static readonly LastSeenMessageList EMPTY = new(Array.Empty<AcknowledgedMessage>());
         public static readonly int MAX_ENTRIES = 5;
 
-        public AcknowledgedMessage[] entries;
-
-        public LastSeenMessageList(AcknowledgedMessage[] list)
-        {
-            entries = list;
-        }
+        public AcknowledgedMessage[] entries = list;
 
         public void WriteForSign(List<byte> data)
         {
@@ -56,16 +51,10 @@ namespace MinecraftClient.Protocol.Message
         /// A record of messages acknowledged by a client.
         /// This holds the messages the client has recently seen, as well as the last message they received, if any.
         /// </summary>
-        public class Acknowledgment
+        public class Acknowledgment(LastSeenMessageList lastSeenMessageList, AcknowledgedMessage? lastReceivedMessage)
         {
-            public LastSeenMessageList lastSeen;
-            public AcknowledgedMessage? lastReceived;
-
-            public Acknowledgment(LastSeenMessageList lastSeenMessageList, AcknowledgedMessage? lastReceivedMessage)
-            {
-                lastSeen = lastSeenMessageList;
-                lastReceived = lastReceivedMessage;
-            }
+            public LastSeenMessageList lastSeen = lastSeenMessageList;
+            public AcknowledgedMessage? lastReceived = lastReceivedMessage;
         }
     }
 
@@ -107,7 +96,7 @@ namespace MinecraftClient.Protocol.Message
                 }
             }
 
-            if (lastEntry != null && messageCount < acknowledgedMessages.Length)
+            if (lastEntry is not null && messageCount < acknowledgedMessages.Length)
                 acknowledgedMessages[messageCount++] = lastEntry;
 
             LastSeenMessageList.AcknowledgedMessage[] msgList = new LastSeenMessageList.AcknowledgedMessage[messageCount];
@@ -120,7 +109,7 @@ namespace MinecraftClient.Protocol.Message
         {
             // net.minecraft.network.message.LastSeenMessagesCollector#add(net.minecraft.network.message.MessageSignatureData, boolean)
             // net.minecraft.network.message.LastSeenMessagesCollector#add(net.minecraft.network.message.AcknowledgedMessage)
-            if (lastEntry != null && entry.signature.SequenceEqual(lastEntry.signature))
+            if (lastEntry is not null && entry.signature.SequenceEqual(lastEntry.signature))
                 return false;
             lastEntry = entry;
 
@@ -143,7 +132,7 @@ namespace MinecraftClient.Protocol.Message
             {
                 int k = (nextIndex + j) % acknowledgedMessages.Length;
                 AcknowledgedMessage? acknowledgedMessage = acknowledgedMessages[k];
-                if (acknowledgedMessage == null)
+                if (acknowledgedMessage is null)
                     continue;
                 bitset[j / 8] |= (byte)(1 << (j % 8)); // bitSet.set(j, true);
                 objectList.Add(acknowledgedMessage);

--- a/MinecraftClient/Protocol/MojangAPI.cs
+++ b/MinecraftClient/Protocol/MojangAPI.cs
@@ -19,19 +19,7 @@ namespace MinecraftClient.Protocol
     /// Information about a players Skin.
     /// Empty string if not available.
     /// </summary>
-    public class SkinInfo
-    {
-        public readonly string SkinUrl;
-        public readonly string CapeUrl;
-        public readonly string SkinModel;
-
-        public SkinInfo(string skinUrl = "", string capeUrl = "", string skinModel = "")
-        {
-            SkinUrl = skinUrl;
-            CapeUrl = capeUrl;
-            SkinModel = skinModel;
-        }
-    }
+    public record SkinInfo(string SkinUrl = "", string CapeUrl = "", string SkinModel = "");
 
     /// <summary>
     /// Status of the single Mojang services
@@ -254,14 +242,14 @@ namespace MinecraftClient.Protocol
             // Can apparently be missing, if no custom skin is set.
             if (textureObj.ContainsKey("SKIN"))
             {
-                return new SkinInfo(skinUrl: textureObj["SKIN"]!["url"] is not null ? textureObj["SKIN"]!["url"]!.GetStringValue() : string.Empty,
-                    capeUrl: textureObj.ContainsKey("CAPE") ? textureObj["CAPE"]!["url"]!.GetStringValue() : string.Empty,
-                    skinModel: textureObj["SKIN"]!["metadata"] is not null ? "Alex" : "Steve");
+                return new SkinInfo(SkinUrl: textureObj["SKIN"]!["url"] is not null ? textureObj["SKIN"]!["url"]!.GetStringValue() : string.Empty,
+                    CapeUrl: textureObj.ContainsKey("CAPE") ? textureObj["CAPE"]!["url"]!.GetStringValue() : string.Empty,
+                    SkinModel: textureObj["SKIN"]!["metadata"] is not null ? "Alex" : "Steve");
             }
             else
             {
-                return new SkinInfo(capeUrl: textureObj.ContainsKey("CAPE") ? textureObj["CAPE"]!["url"]!.GetStringValue() : string.Empty,
-                    skinModel: DefaultModelAlex(uuid) ? "Alex" : "Steve");
+                return new SkinInfo(CapeUrl: textureObj.ContainsKey("CAPE") ? textureObj["CAPE"]!["url"]!.GetStringValue() : string.Empty,
+                    SkinModel: DefaultModelAlex(uuid) ? "Alex" : "Steve");
             }
         }
 

--- a/MinecraftClient/Protocol/PlayerInfo.cs
+++ b/MinecraftClient/Protocol/PlayerInfo.cs
@@ -44,13 +44,13 @@ namespace MinecraftClient.Protocol
         {
             Uuid = uuid;
             Name = name;
-            if (property != null)
+            if (property is not null)
                 Property = property;
             Gamemode = gamemode;
             Ping = ping;
             DisplayName = displayName;
             lastMessageVerified = false;
-            if (timeStamp != null && publicKey != null && signature != null)
+            if (timeStamp is not null && publicKey is not null && signature is not null)
             {
                 DateTimeOffset dateTimeOffset = DateTimeOffset.FromUnixTimeMilliseconds((long)timeStamp);
                 KeyExpiresAt = dateTimeOffset.UtcDateTime;
@@ -119,7 +119,7 @@ namespace MinecraftClient.Protocol
         /// <returns>Is this message vaild</returns>
         public bool VerifyMessage(string message, long timestamp, long salt, ref byte[] signature)
         {
-            if (PublicKey == null || IsKeyExpired())
+            if (PublicKey is null || IsKeyExpired())
                 return false;
             else
             {
@@ -146,12 +146,12 @@ namespace MinecraftClient.Protocol
         {
             if (lastMessageVerified == false)
                 return false;
-            if (PublicKey == null || IsKeyExpired() || (this.precedingSignature != null && precedingSignature == null))
+            if (PublicKey is null || IsKeyExpired() || (this.precedingSignature is not null && precedingSignature is null))
             {
                 lastMessageVerified = false;
                 return false;
             }
-            if (this.precedingSignature != null && !this.precedingSignature.SequenceEqual(precedingSignature!))
+            if (this.precedingSignature is not null && !this.precedingSignature.SequenceEqual(precedingSignature!))
             {
                 lastMessageVerified = false;
                 return false;
@@ -181,12 +181,12 @@ namespace MinecraftClient.Protocol
         {
             if (lastMessageVerified == false)
                 return false;
-            if (PublicKey == null || IsKeyExpired() || (this.precedingSignature != null && precedingSignature == null))
+            if (PublicKey is null || IsKeyExpired() || (this.precedingSignature is not null && precedingSignature is null))
             {
                 lastMessageVerified = false;
                 return false;
             }
-            if (this.precedingSignature != null && !this.precedingSignature.SequenceEqual(precedingSignature!))
+            if (this.precedingSignature is not null && !this.precedingSignature.SequenceEqual(precedingSignature!))
             {
                 lastMessageVerified = false;
                 return false;
@@ -212,7 +212,7 @@ namespace MinecraftClient.Protocol
         /// <returns>Is this message chain vaild</returns>
         public bool VerifyMessage(string message, Guid playerUuid, Guid chatUuid, int messageIndex, long timestamp, long salt, ref byte[] signature, Tuple<int, byte[]?>[] previousMessageSignatures)
         {
-            if (PublicKey == null || IsKeyExpired())
+            if (PublicKey is null || IsKeyExpired())
                 return false;
 
             // net.minecraft.server.network.ServerPlayNetworkHandler#validateMessage

--- a/MinecraftClient/Protocol/ProfileKey/KeyUtils.cs
+++ b/MinecraftClient/Protocol/ProfileKey/KeyUtils.cs
@@ -43,7 +43,7 @@ namespace MinecraftClient.Protocol.ProfileKey
             }
             catch (Exception e)
             {
-                int code = response == null ? 0 : response.StatusCode;
+                int code = response is null ? 0 : response.StatusCode;
                 ConsoleIO.WriteLineFormatted("§cFetch authlib-injector metadata failed: HttpCode = " + code + ", Error = " + e.Message);
                 if (Settings.Config.Logging.DebugMessages)
                     ConsoleIO.WriteLineFormatted("§c" + e.StackTrace);
@@ -93,12 +93,12 @@ namespace MinecraftClient.Protocol.ProfileKey
                 }
 
                 var json = Json.ParseJson(response.Body);
-                if (json?["keyPair"]?["publicKey"] == null
-                    || json["keyPair"]?["privateKey"] == null
-                    || json["publicKeySignature"] == null
-                    || json["publicKeySignatureV2"] == null
-                    || json["expiresAt"] == null
-                    || json["refreshedAfter"] == null)
+                if (json?["keyPair"]?["publicKey"] is null
+                    || json["keyPair"]?["privateKey"] is null
+                    || json["publicKeySignature"] is null
+                    || json["publicKeySignatureV2"] is null
+                    || json["expiresAt"] is null
+                    || json["refreshedAfter"] is null)
                 {
                     throw new InvalidOperationException("Certificate endpoint returned an unexpected payload.");
                 }
@@ -115,7 +115,7 @@ namespace MinecraftClient.Protocol.ProfileKey
             }
             catch (Exception e)
             {
-                int code = response == null ? 0 : response.StatusCode;
+                int code = response is null ? 0 : response.StatusCode;
                 ConsoleIO.WriteLineFormatted("§cFetch profile key failed: HttpCode = " + code + ", Error = " + e.Message);
                 if (Settings.Config.Logging.DebugMessages)
                     ConsoleIO.WriteLineFormatted("§c" + e.StackTrace);
@@ -209,7 +209,7 @@ namespace MinecraftClient.Protocol.ProfileKey
         {
             List<byte> data = new();
 
-            if (precedingSignature != null)
+            if (precedingSignature is not null)
                 data.AddRange(precedingSignature);
 
             data.AddRange(sender.ToBigEndianBytes());

--- a/MinecraftClient/Protocol/ProfileKey/PlayerKeyPair.cs
+++ b/MinecraftClient/Protocol/ProfileKey/PlayerKeyPair.cs
@@ -73,11 +73,11 @@ namespace MinecraftClient.Protocol.ProfileKey
         {
             List<string> datas = new();
             datas.Add(Convert.ToBase64String(PublicKey.Key));
-            if (PublicKey.Signature == null)
+            if (PublicKey.Signature is null)
                 datas.Add(string.Empty);
             else
                 datas.Add(Convert.ToBase64String(PublicKey.Signature));
-            if (PublicKey.SignatureV2 == null)
+            if (PublicKey.SignatureV2 is null)
                 datas.Add(string.Empty);
             else
                 datas.Add(Convert.ToBase64String(PublicKey.SignatureV2));

--- a/MinecraftClient/Protocol/ProfileKey/PublicKey.cs
+++ b/MinecraftClient/Protocol/ProfileKey/PublicKey.cs
@@ -25,10 +25,10 @@ namespace MinecraftClient.Protocol.ProfileKey
             if (!string.IsNullOrEmpty(sigV2))
                 SignatureV2 = Convert.FromBase64String(sigV2!);
 
-            if (SignatureV2 == null || SignatureV2.Length == 0)
+            if (SignatureV2 is null || SignatureV2.Length == 0)
                 SignatureV2 = Signature;
 
-            if (Signature == null || Signature.Length == 0)
+            if (Signature is null || Signature.Length == 0)
                 Signature = SignatureV2;
         }
 

--- a/MinecraftClient/Protocol/ProtocolHandler.cs
+++ b/MinecraftClient/Protocol/ProtocolHandler.cs
@@ -932,7 +932,7 @@ namespace MinecraftClient.Protocol
                 int code = DoHTTPSPost("authserver.mojang.com", 443, "/refresh", json_request, ref result);
                 if (code == 200)
                 {
-                    if (result == null)
+                    if (result is null)
                     {
                         return LoginResult.NullError;
                     }
@@ -983,7 +983,7 @@ namespace MinecraftClient.Protocol
                     Config.Main.General.AuthServer.UseHttps, ref result);
                 if (code == 200)
                 {
-                    if (result == null)
+                    if (result is null)
                     {
                         return LoginResult.NullError;
                     }
@@ -1258,7 +1258,7 @@ namespace MinecraftClient.Protocol
                             contentType = header.Value;
                     }
 
-                    if (body != null)
+                    if (body is not null)
                         request.Content = new StringContent(body, Encoding.UTF8, contentType);
 
                     if (Settings.Config.Logging.DebugMessages)
@@ -1286,9 +1286,9 @@ namespace MinecraftClient.Protocol
                     }
                 }
             }, TimeSpan.FromSeconds(30));
-            if (postResult != null)
+            if (postResult is not null)
                 result = postResult;
-            if (exception != null)
+            if (exception is not null)
                 throw exception;
             return statusCode;
         }

--- a/MinecraftClient/Protocol/ProxiedWebRequest.cs
+++ b/MinecraftClient/Protocol/ProxiedWebRequest.cs
@@ -202,21 +202,8 @@ namespace MinecraftClient.Protocol
         /// <summary>
         /// Basic HTTP response object.
         /// </summary>
-        public class Response
+        public record Response(int StatusCode, string Body, NameValueCollection Headers, NameValueCollection Cookies)
         {
-            public int StatusCode;
-            public string Body;
-            public NameValueCollection Headers;
-            public NameValueCollection Cookies;
-
-            public Response(int statusCode, string body, NameValueCollection headers, NameValueCollection cookies)
-            {
-                StatusCode = statusCode;
-                Body = body;
-                Headers = headers;
-                Cookies = cookies;
-            }
-
             public static Response Empty() =>
                 new(204, "", new NameValueCollection(), new NameValueCollection());
 

--- a/MinecraftClient/Protocol/Session/SessionToken.cs
+++ b/MinecraftClient/Protocol/Session/SessionToken.cs
@@ -45,7 +45,7 @@ namespace MinecraftClient.Protocol.Session
 
         public bool SessionPreCheck(LoginType type)
         {
-            if (ID == string.Empty || PlayerID == String.Empty || ServerPublicKey == null)
+            if (ID == string.Empty || PlayerID == String.Empty || ServerPublicKey is null)
                 return false;
             Crypto.CryptoHandler.ClientAESPrivateKey ??= Crypto.CryptoHandler.GenerateAESPrivateKey();
             string serverHash = Crypto.CryptoHandler.GetServerHash(ServerIDhash, ServerPublicKey, Crypto.CryptoHandler.ClientAESPrivateKey);
@@ -57,7 +57,7 @@ namespace MinecraftClient.Protocol.Session
         public override string ToString()
         {
             return String.Join(",", ID, PlayerName, PlayerID, ClientID, RefreshToken, ServerIDhash,
-                (ServerPublicKey == null) ? String.Empty : Convert.ToBase64String(ServerPublicKey));
+                (ServerPublicKey is null) ? String.Empty : Convert.ToBase64String(ServerPublicKey));
         }
 
         public static SessionToken FromString(string tokenString)

--- a/MinecraftClient/Scripting/CSharpRunner.cs
+++ b/MinecraftClient/Scripting/CSharpRunner.cs
@@ -109,7 +109,7 @@ namespace MinecraftClient.Scripting
                     var result = compiler.Compile(code, Guid.NewGuid().ToString(), dlls);
 
                     //Process compile warnings and errors
-                    if (result.Failures != null)
+                    if (result.Failures is not null)
                     {
 
                         ConsoleIO.WriteLogLine("[Script] Compilation failed with error(s):");
@@ -309,7 +309,7 @@ namespace MinecraftClient.Scripting
         /// <returns>Value of the variable or null if no variable</returns>
         public object? GetVar(string varName)
         {
-            if (localVars != null && localVars.ContainsKey(varName))
+            if (localVars is not null && localVars.ContainsKey(varName))
                 return localVars[varName];
             else
                 return Config.AppVar.GetVar(varName);
@@ -322,7 +322,7 @@ namespace MinecraftClient.Scripting
         /// <param name="varValue">Value of the variable</param>
         public bool SetVar(string varName, object varValue)
         {
-            if (localVars != null && localVars.ContainsKey(varName))
+            if (localVars is not null && localVars.ContainsKey(varName))
                 localVars.Remove(varName);
             return Config.AppVar.SetVar(varName, varValue);
         }
@@ -339,12 +339,12 @@ namespace MinecraftClient.Scripting
             object? value = GetVar(varName);
             if (value is T Tval)
                 return Tval;
-            if (value != null)
+            if (value is not null)
             {
                 try
                 {
                     TypeConverter converter = TypeDescriptor.GetConverter(typeof(T));
-                    if (converter != null)
+                    if (converter is not null)
                         return (T?)converter.ConvertFromString(value.ToString() ?? string.Empty);
                 }
                 catch (NotSupportedException) { /* Was worth trying */ }

--- a/MinecraftClient/Scripting/ChatBot.cs
+++ b/MinecraftClient/Scripting/ChatBot.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using Brigadier.NET;
 using MinecraftClient.CommandHandler;
 using MinecraftClient.Inventory;
@@ -42,15 +43,15 @@ namespace MinecraftClient.Scripting
         private McClient? _handler = null;
         private ChatBot? master = null;
         private readonly List<string> registeredPluginChannels = new();
-        private readonly object delayTasksLock = new();
+        private readonly Lock delayTasksLock = new();
         private readonly List<TaskWithDelay> delayedTasks = new();
         protected McClient Handler
         {
             get
             {
-                if (master != null)
+                if (master is not null)
                     return master.Handler;
-                if (_handler != null)
+                if (_handler is not null)
                     return _handler;
                 throw new InvalidOperationException(Translations.exception_chatbot_init);
             }
@@ -784,7 +785,7 @@ namespace MinecraftClient.Scripting
                         string prefix = tmp[0];
                         string user = tmp[1];
                         string semicolon = tmp[2];
-                        if (prefix.All(c => char.IsLetterOrDigit(c) || new char[] { '*', '<', '>', '_' }.Contains(c))
+                        if (prefix.All(c => char.IsLetterOrDigit(c) || new[] { '*', '<', '>', '_' }.Contains(c))
                             && semicolon == ":")
                         {
                             message = text[(prefix.Length + user.Length + 4)..];
@@ -861,7 +862,7 @@ namespace MinecraftClient.Scripting
         protected void LogToConsole(object? text)
         {
             string botName = Translations.ResourceManager.GetString("botname." + GetType().Name) ?? GetType().Name;
-            if (_handler == null || master == null)
+            if (_handler is null || master is null)
                 ConsoleIO.WriteLogLine(string.Format("[{0}] {1}", botName, text));
             else
                 Handler.Log.Info(string.Format("[{0}] {1}", botName, text));
@@ -877,7 +878,7 @@ namespace MinecraftClient.Scripting
                     catch { return; /* Invalid file name or access denied */ }
                 }
 
-                File.AppendAllLines(logfile, new string[] { GetTimestamp() + ' ' + text });
+                File.AppendAllLines(logfile, [GetTimestamp() + ' ' + text]);
             }
         }
 
@@ -897,7 +898,7 @@ namespace MinecraftClient.Scripting
                     catch { return; /* Invalid file name or access denied */ }
                 }
 
-                File.AppendAllLines(logfile, new string[] { GetTimestamp() + ' ' + text });
+                File.AppendAllLines(logfile, [GetTimestamp() + ' ' + text]);
             }
         }
 
@@ -1217,7 +1218,7 @@ namespace MinecraftClient.Scripting
             else
             {
                 LogToConsole("File not found: " + Path.GetFullPath(file));
-                return Array.Empty<string>();
+                return [];
             }
         }
 

--- a/MinecraftClient/Scripting/DynamicRun/Builder/Compiler.cs
+++ b/MinecraftClient/Scripting/DynamicRun/Builder/Compiler.cs
@@ -82,6 +82,8 @@ namespace MinecraftClient.Scripting.DynamicRun.Builder
             {
                 // Create a temporary file to copy the executable to.
                 var executablePath = Environment.ProcessPath;
+                if (executablePath is null)
+                    throw new InvalidOperationException("Cannot determine the process path for self-contained scripting extraction.");
                 var tempPath = Path.Combine(Path.GetTempPath(), "mcc-scripting");
                 Directory.CreateDirectory(tempPath);
                 
@@ -142,7 +144,7 @@ namespace MinecraftClient.Scripting.DynamicRun.Builder
                                 "[Script Error] Too many references to the same assembly. Assembly name: " + refs.Name);
                         }
 
-                        if (reference == null) {
+                        if (reference is null) {
                             throw new InvalidOperationException(
                                 "[Script Error] The executable does not contain a referenced assembly. Assembly name: " + refs.Name);
                         }

--- a/MinecraftClient/Settings.cs
+++ b/MinecraftClient/Settings.cs
@@ -1011,7 +1011,7 @@ namespace MinecraftClient
                 private readonly Dictionary<string, object> VarObject = new();
 
                 [NonSerialized]
-                readonly object varLock = new();
+                readonly Lock varLock = new();
 
                 /// <summary>
                 /// Set a custom %variable% which will be available through expandVars()
@@ -1150,7 +1150,7 @@ namespace MinecraftClient
 
                                         break;
                                     default:
-                                        if (localVars != null && localVars.ContainsKey(varname_lower))
+                                        if (localVars is not null && localVars.ContainsKey(varname_lower))
                                             result.Append(localVars[varname_lower].ToString());
                                         else if (TryGetVar(varname_lower, out object? var_value))
                                             result.Append(var_value.ToString());
@@ -1979,7 +1979,7 @@ namespace MinecraftClient
         public static string GetFullMessage(this Exception ex)
         {
             string msg = ex.Message.Replace("+", "->");
-            return ex.InnerException == null
+            return ex.InnerException is null
                  ? msg
                  : msg + "\n --> " + ex.InnerException.GetFullMessage();
         }

--- a/MinecraftClient/TaskWithResult.cs
+++ b/MinecraftClient/TaskWithResult.cs
@@ -14,7 +14,7 @@ namespace MinecraftClient
         private T? result = default;
         private Exception? exception = null;
         private bool taskRun = false;
-        private readonly object taskRunLock = new();
+        private readonly Lock taskRunLock = new();
 
         /// <summary>
         /// Create a new asynchronous task with return value
@@ -113,7 +113,7 @@ namespace MinecraftClient
             }
 
             // Receive exception from task
-            if (exception != null)
+            if (exception is not null)
                 throw exception;
 
             return result!;

--- a/MinecraftClient/UpgradeHelper.cs
+++ b/MinecraftClient/UpgradeHelper.cs
@@ -211,7 +211,7 @@ namespace MinecraftClient
                 if (!cancellationToken.IsCancellationRequested)
                 {
                     HttpResponseMessage res = httpWebRequest.Result;
-                    if (res.Headers.Location != null)
+                    if (res.Headers.Location is not null)
                     {
                         Match match = Regex.Match(res.Headers.Location.ToString(), GithubReleaseUrl + @"/tag/(\d{4})(\d{2})(\d{2})-(\d+)");
                         if (match.Success && match.Groups.Count == 5)
@@ -284,7 +284,7 @@ namespace MinecraftClient
 
         private static bool CompareVersionInfo(string? current, string? latest)
         {
-            if (current == null || latest == null)
+            if (current is null || latest is null)
                 return false;
             Regex reg = new(@"\w+\sbuild\s(\d+),\sbuilt\son\s(\d{4})[-\/\.\s]?(\d{2})[-\/\.\s]?(\d{2}).*");
             Regex reg2 = new(@"\w+\sbuild\s(\d+),\sbuilt\son\s\w+\s(\d{2})[-\/\.\s]?(\d{2})[-\/\.\s]?(\d{4}).*");
@@ -297,13 +297,13 @@ namespace MinecraftClient
                 try { curTime = new(int.Parse(curMatch.Groups[2].Value), int.Parse(curMatch.Groups[3].Value), int.Parse(curMatch.Groups[4].Value)); }
                 catch { curTime = null; }
             }
-            if (curTime == null)
+            if (curTime is null)
             {
                 curMatch = reg2.Match(current);
                 try { curTime = new(int.Parse(curMatch.Groups[4].Value), int.Parse(curMatch.Groups[3].Value), int.Parse(curMatch.Groups[2].Value)); }
                 catch { curTime = null; }
             }
-            if (curTime == null)
+            if (curTime is null)
                 return false;
 
             Match latestMatch = reg.Match(latest);
@@ -312,13 +312,13 @@ namespace MinecraftClient
                 try { latestTime = new(int.Parse(latestMatch.Groups[2].Value), int.Parse(latestMatch.Groups[3].Value), int.Parse(latestMatch.Groups[4].Value)); }
                 catch { latestTime = null; }
             }
-            if (latestTime == null)
+            if (latestTime is null)
             {
                 latestMatch = reg2.Match(latest);
                 try { latestTime = new(int.Parse(latestMatch.Groups[4].Value), int.Parse(latestMatch.Groups[3].Value), int.Parse(latestMatch.Groups[2].Value)); }
                 catch { latestTime = null; }
             }
-            if (latestTime == null)
+            if (latestTime is null)
                 return false;
 
             int curBuildId, latestBuildId;

--- a/MinecraftClient/config/sample-script-packet-capture.cs
+++ b/MinecraftClient/config/sample-script-packet-capture.cs
@@ -4,12 +4,14 @@ MCC.LoadBot(new PacketCadenceCaptureBot());
 
 //MCCScript Extensions
 
+using System.Threading;
+
 public class PacketCadenceCaptureBot : ChatBot
 {
     private const int CaptureDurationSeconds = 5;
     private const int CaptureDurationTicks = CaptureDurationSeconds * 20;
 
-    private readonly object _countsLock = new();
+    private readonly Lock _countsLock = new();
     private readonly Dictionary<string, int> _counts = new()
     {
         { "PlayerMovement", 0 },


### PR DESCRIPTION
## Summary

This PR is primarily a C# 14 refactor and modernization branch for MCC.

The main goal is to move the codebase toward a cleaner C# 14 / .NET 10 style, reduce compiler noise, and modernize common patterns without changing intended behavior.

As a secondary item uncovered during validation, this PR also fixes inventory slot encoding and decoding issues across older protocol boundaries, including:

- the `1.12.2` creative inventory disconnect
- the `1.13` / `1.13.1` item slot decode and encode mismatch
- the `1.13` join-time inventory packet crash

## Main Refactor Work

This branch modernizes the codebase with a number of C# 14 style updates, including:

- converting suitable data carriers to records and primary constructors
- replacing older switch statements with switch expressions where appropriate
- adopting collection expressions
- using target-typed `new()`
- standardizing null checks to `is null` / `is not null`
- modernizing lock usage to `System.Threading.Lock`
- resolving CS9107 and related compiler / nullable warnings introduced during the refactor

The intent of this part of the PR is code quality and maintainability first, while preserving runtime behavior.

## Secondary Bug Fix

While validating the refactor branch across supported Minecraft versions, an inventory slot protocol issue was identified and fixed around the `1.13` / `1.13.2` transition.

The correct item slot format split is now handled as:

- `>= 1.20.6`: structured components format
- `>= 1.13.2`: `bool present + VarInt itemId + byte count + NBT`
- `>= 1.13`: `short itemId + byte count + NBT`
- `< 1.13`: `short itemId + byte count + short damage + NBT`

This also preserves the `1.12.2` fix where legacy item damage/data must be written as a `short`, not a `byte`, to avoid disconnecting after `inventory creativegive`.

## Validation

All tests below were run with offline CLI login only:

- `Account = { Login = "CursorBot", Password = "-" }`
- no Microsoft login used

| Version   | Offline login | Join | Chat send/receive | Commands | Terrain / movement | Inventory | Mobs | Particles / sounds / effects / entity data | Result   | Notes |
|-----------|---------------|------|-------------------|----------|---------------------|-----------|------|-------------------------------------------|----------|-------|
| `1.8`     | ✅            | ✅   | ✅                | ✅       | ✅                  | ✅        | ✅   | ✅                                        | ✅ Pass  | Full spectrum regression |
| `1.8.9`   | ✅            | ✅   | ✅                | ✅       | ✅                  | ✅        | ✅   | ✅                                        | ✅ Pass  | Full spectrum regression |
| `1.12.2`  | ✅            | ✅   | ✅                | ✅       | ✅                  | ✅        | ✅   | ✅                                        | ✅ Pass  | Includes fixed creative inventory regression |
| `1.13`    | ✅            | ✅   | ✅                | ✅       | ✅                  | ✅        | ✅   | ✅                                        | ✅ Pass  | Join/inventory crash fixed |
| `1.13.2`  | ✅            | ✅   | ✅                | ✅       | ✅                  | ✅        | ✅   | ✅                                        | ✅ Pass  | Protocol boundary regression check |
| `1.16.2`  | ✅            | ✅   | ✅                | ✅       | ✅                  | ✅        | ✅   | ✅                                        | ✅ Pass  | Full coverage follow-up |
| `1.20.4`  | ✅            | ✅   | ✅                | ✅       | ✅                  | ✅        | ✅   | ✅                                        | ✅ Pass  | Full coverage rerun with explicit offline launch |
| `1.20.6`  | ✅            | ✅   | ✅                | ✅       | ✅                  | ✅        | ✅   | ✅                                        | ✅ Pass  | Full spectrum regression |
| `1.21.1`  | ✅            | ✅   | ✅                | ✅       | ✅                  | ✅        | ✅   | ✅                                        | ✅ Pass  | Full spectrum regression |
| `1.21.2`  | ✅            | ✅   | ✅                | ✅       | ✅                  | ✅        | ✅   | ✅                                        | ✅ Pass  | Previously investigated crash path revalidated |
| `1.21.3`  | ✅            | ✅   | ✅                | ✅       | ✅                  | ✅        | ✅   | ✅                                        | ✅ Pass  | Full spectrum regression |
| `1.21.4`  | ✅            | ✅   | ✅                | ✅       | ✅                  | ✅        | ✅   | ✅                                        | ✅ Pass  | Full spectrum regression |
| `1.21.5`  | ✅            | ✅   | ✅                | ✅       | ✅                  | ✅        | ✅   | ✅                                        | ✅ Pass  | Full spectrum regression |
| `1.21.6`  | ✅            | ✅   | ✅                | ✅       | ✅                  | ✅        | ✅   | ✅                                        | ✅ Pass  | Full spectrum regression |
| `1.21.7`  | ✅            | ✅   | ✅                | ✅       | ✅                  | ✅        | ✅   | ✅                                        | ✅ Pass  | Full spectrum regression |
| `1.21.8`  | ✅            | ✅   | ✅                | ✅       | ✅                  | ✅        | ✅   | ✅                                        | ✅ Pass  | Full spectrum regression |
| `1.21.9`  | ✅            | ✅   | ✅                | ✅       | ✅                  | ✅        | ✅   | ✅                                        | ✅ Pass  | Full spectrum regression |
| `1.21.10` | ✅            | ✅   | ✅                | ✅       | ✅                  | ✅        | ✅   | ✅                                        | ✅ Pass  | Full spectrum regression |
| `1.21.11` | ✅            | ✅   | ✅                | ✅       | ✅                  | ✅        | ✅   | ✅                                        | ✅ Pass  | Full coverage rerun with explicit offline launch |

## Result

- no client crashes on the tested versions
- no server-side decode exceptions in the tested inventory flows
- `1.12.2` creative inventory disconnect fixed
- `1.13` join crash fixed
- no regression found across the tested older and newer versions

## Notes

The primary purpose of this PR is the C# 14 modernization and refactor work.

The protocol fix is included because it was uncovered during real end-to-end validation and needed to be corrected to keep the branch safe across older supported versions.