### PR TITLE
chores: Update build-and-release.yml

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -9,19 +9,25 @@ on:
 env:
   PROJECT: "MinecraftClient"
   target-version: "net10.0"
-  compile-flags: "--self-contained=true -c Release -p:UseAppHost=true -p:IncludeNativeLibrariesForSelfExtract=true -p:EnableCompressionInSingleFile=true -p:DebugType=Embedded"
+  dotnet-version: "10.0.x"
+  compile-flags: "--self-contained=true -c Release -p:UseAppHost=true -p:IncludeNativeLibrariesForSelfExtract=true -p:EnableCompressionInSingleFile=true -p:DebugType=Embedded -p:PublishSingleFile=true"
 
 jobs:
   determine-build:
     runs-on: ubuntu-slim
-    if: >-
-      ${{
-        !contains(github.event.head_commit.message, 'skipci') &&
-        !contains(github.event.pull_request.title, 'skipci')
-      }}
+    outputs:
+      skip: ${{ steps.check-skip.outputs.skip }}
     steps:
-      - name: dummy action
-        run: "echo 'dummy action that checks if the build is to be skipped, if it is, this action does not run to break the entire build action'"        
+    - name: Check skip CI
+      id: check-skip
+      run: |
+        MSG="${{ github.event.head_commit.message }}"
+        LOWER=$(echo "$MSG" | tr '[:upper:]' '[:lower:]')
+        if echo "$LOWER" | grep -qE 'skip.?ci|ci.?skip'; then
+          echo "skip=true" >> $GITHUB_OUTPUT
+        else
+          echo "skip=false" >> $GITHUB_OUTPUT
+        fi      
 
   fetch-translations:
     strategy:
@@ -29,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: determine-build
     # Translations will only be fetched in the MCCTeam repository, since it needs crowdin secrets.
-    if: ${{ github.repository == 'MCCTeam/Minecraft-Console-Client' }}
+    if: ${{ needs.determine-build.outputs.skip != 'true' && github.repository == 'MCCTeam/Minecraft-Console-Client' }}
     timeout-minutes: 15
   
     steps:   
@@ -77,8 +83,8 @@ jobs:
   create-tag:
     runs-on: ubuntu-slim
     timeout-minutes: 5 # Wait 5 minutes in case of network issues/etc
-    needs: [determine-build]
-    if: ${{ needs.determine-build.result == 'success' }}
+    needs: determine-build
+    if: ${{ needs.determine-build.outputs.skip != 'true' }}
     steps:
       - id: make-tag
         run: |
@@ -111,9 +117,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     # Check if we're not skipping build, tag is created, and translations successfully fetched (or skipped)
-    if: ${{ needs.determine-build.result == 'success' && 
-            needs.create-tag.result == 'success' && 
-            (needs.fetch-translations.result == 'success' || needs.fetch-translations.result == 'skipped') 
+    if: ${{ needs.determine-build.outputs.skip != 'true' &&
+            needs.create-tag.result == 'success' &&
+            (needs.fetch-translations.result == 'success' || needs.fetch-translations.result == 'skipped')
           }}
     needs: [determine-build, fetch-translations, create-tag]
     timeout-minutes: 15
@@ -130,7 +136,6 @@ jobs:
         
     - name: Get Current Date
       run: |
-        echo date=$(date +'%Y%m%d') >> $GITHUB_ENV
         echo date_dashed=$(date -u +'%Y-%m-%d') >> $GITHUB_ENV
         
     - name: Restore Translations (if available)
@@ -140,33 +145,34 @@ jobs:
         key: "translation-${{ github.sha }}"
         restore-keys: "translation-"
           
-    - name: Setup Environment Variables (early)
-      run: |
-        echo project-path=${{ github.workspace }}/${{ env.PROJECT }} >> $GITHUB_ENV
-        echo file-ext=${{ (startsWith(matrix.target, 'win') && '.exe') || '' }} >> $GITHUB_ENV
-
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 10.0.x
+        dotnet-version: ${{ env.dotnet-version }}
         
     - name: Setup Environment Variables
       run: |
-        echo target-out-path=${{ env.project-path }}/bin/Release/${{ env.target-version }}/${{ matrix.target }}/publish/ >> $GITHUB_ENV
-        echo assembly-info=${{ env.project-path }}/Properties/AssemblyInfo.cs >> $GITHUB_ENV
-        echo build-version-info=${{ needs.create-tag.outputs.build-tag }} >> $GITHUB_ENV
-        echo commit=$(echo ${{ github.sha }} | cut -c 1-7) >> $GITHUB_ENV
+        PROJECT_PATH=${{ github.workspace }}/${{ env.PROJECT }}
+        FILE_EXT=${{ (startsWith(matrix.target, 'win') && '.exe') || '' }}
+        TARGET_OUT_PATH=$PROJECT_PATH/bin/Release/${{ env.target-version }}/${{ matrix.target }}/publish/
+    
+        echo "project-path=$PROJECT_PATH" >> $GITHUB_ENV
+        echo "file-ext=$FILE_EXT" >> $GITHUB_ENV
+        echo "target-out-path=$TARGET_OUT_PATH" >> $GITHUB_ENV
+        echo "assembly-info=$PROJECT_PATH/Properties/AssemblyInfo.cs" >> $GITHUB_ENV
+        echo "build-version-info=${{ needs.create-tag.outputs.build-tag }}" >> $GITHUB_ENV
+        echo "commit=$(echo ${{ github.sha }} | cut -c 1-7)" >> $GITHUB_ENV
         
-    - name: Setup Environment Variables (late)
+    - name: Setup Binaries Path
       run: |
         echo built-executable-path=${{ env.target-out-path }}${{ env.PROJECT }}${{ env.file-ext }} >> $GITHUB_ENV
 
-    - name: Set Version Info and Sentry Project (if applicable)
+    - name: Set Version Info
       run: |
         echo '' >> ${{ env.assembly-info }}
-        echo "[assembly: AssemblyConfiguration(\"GitHub build ${{ github.run_number }}, built on ${{ env.date_dashed }} from commit ${{ env.commit }}\")]" >> ${{ env.assembly-info }}
+        echo "[assembly: AssemblyConfiguration(\"GitHub build ${{ github.run_number }}, built on ${{ env._dashed }} from commit ${{ env.commit }}\")]" >> ${{ env.assembly-info }}
         
-    - name: Inject Sentry DSN
+    - name: Inject Sentry DSN (if applicable)
       if: ${{ github.repository == 'MCCTeam/Minecraft-Console-Client' }}
       run: |
         grep -q 'SentryDSN = "";' ${{ env.project-path }}/Program.cs || { echo "SentryDSN pattern not found in Program.cs"; exit 1; }
@@ -198,6 +204,16 @@ jobs:
         with:
           path: artifacts/
           merge-multiple: true
+
+      - name: Truncate commit message for release name
+        id: release-name
+        run: |
+           RAW="${{ github.event.head_commit.message }}"
+           # Take only the first line (subject), then truncate to safe length
+           SUBJECT=$(echo "$RAW" | head -n 1)
+           MAX=220  # leave room for tag prefix + ": "
+           TRUNCATED="${SUBJECT:0:$MAX}"
+           echo "name=${{ needs.create-tag.outputs.build-tag }}: $TRUNCATED" >> $GITHUB_OUTPUT
           
       - name: Create Release
         uses: ncipollo/release-action@v1.14.0
@@ -205,7 +221,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           artifacts: "artifacts/**/*"
           tag: ${{ needs.create-tag.outputs.build-tag }}
-          name: '${{ needs.create-tag.outputs.build-tag }}: ${{ github.event.head_commit.message }}'
+          name: ${{ steps.release-name.outputs.name }}
           generateReleaseNotes: true
           artifactErrorsFailBuild: true
           allowUpdates: true


### PR DESCRIPTION
Fixes long commit message >256 chars breaking releases 
Cleanup comments and consolidate variables
Make skip ci more user-friendly by including all variations of skip-ci and ci-skip