### PR TITLE
fix: work around Consolonia libcoreclr.so DllNotFoundException on Linux single-file publish

### DIFF
--- a/MinecraftClient/Program.cs
+++ b/MinecraftClient/Program.cs
@@ -4,6 +4,8 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Runtime.Loader;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -174,6 +176,9 @@ namespace MinecraftClient
             };
 
             // --- Determine console mode and initialize backend ---
+            if (!OperatingSystem.IsWindows())
+                InstallCursesNativeResolver();
+
             if (!ConsoleIO.BasicIO && Config.Console.General.ConsoleMode == ConsoleModeType.tui)
             {
                 ConsoleIO.Backend?.Shutdown();
@@ -204,6 +209,26 @@ namespace MinecraftClient
             // MaybePrintClassicModeTuiRecommendation();
 
             RunStartupSequence(args);
+        }
+
+        /// <summary>
+        /// Consolonia's Unix.Terminal uses <c>[DllImport("libcoreclr.so")]</c> to reach
+        /// <c>dlopen</c>/<c>dlsym</c> on .NET Core. The library ships a
+        /// <c>SetDllImportResolver</c> that maps <c>libcoreclr.so</c> to the current
+        /// process, but it is compiled under <c>#if NET6_0</c> (exact TFM match) instead
+        /// of <c>NET6_0_OR_GREATER</c>, so it is dead code when the consuming project
+        /// targets net8.0+. On a self-contained single-file publish the physical
+        /// <c>libcoreclr.so</c> does not exist on the search path, causing a
+        /// <c>DllNotFoundException</c> that crashes the TUI.
+        ///
+        /// We work around this by registering our own resolver before any Consolonia
+        /// code runs: if any assembly asks for <c>libcoreclr.so</c> we return
+        /// <c>(IntPtr)(-1)</c> which the runtime interprets as "the current process".
+        /// </summary>
+        private static void InstallCursesNativeResolver()
+        {
+            AssemblyLoadContext.Default.ResolvingUnmanagedDll += (assembly, libraryName) =>
+                libraryName == "libcoreclr.so" ? (IntPtr)(-1) : IntPtr.Zero;
         }
 
         private static void HandleTuiStartupFailure(Exception exception)


### PR DESCRIPTION
## Problem

TUI mode crashes on startup with `DllNotFoundException: Unable to load shared library 'libcoreclr.so'` when MCC is published as a self-contained single-file app for Linux. This primarily affects ARM64 users (e.g. Raspberry Pi running Debian Trixie) who almost exclusively use self-contained publishes, but can also occur on x86_64 systems that don't have a system-wide .NET runtime installed.

```
Unhandled exception. System.DllNotFoundException: Unable to load shared library 'libcoreclr.so' or one of its dependencies.
   at Unix.Terminal.UnmanagedLibrary.CoreCLR.dlopen(String filename, Int32 flags)
   at Unix.Terminal.UnmanagedLibrary.PlatformSpecificLoadLibrary(String libraryPath)
   at Unix.Terminal.Curses.LoadMethods()
   at Unix.Terminal.Curses.FindNCurses()
   at Unix.Terminal.Curses.initscr()
   at Consolonia.PlatformSupport.CursesConsole.PrepareConsole()
   ...
```

Classic mode is unaffected.

## Root Cause

Consolonia's `Unix.Terminal.UnmanagedLibrary.CoreCLR` class uses `[DllImport("libcoreclr.so")]` to obtain `dlopen`/`dlsym`. It has a `SetDllImportResolver` that maps this to the current process handle `(IntPtr)(-1)`, but this resolver is guarded by `#if NET6_0` -- an exact TFM symbol that is only defined when the target framework is precisely `net6.0`. Since Consolonia's `Directory.Build.props` targets `net8.0`, the resolver is never compiled in and is effectively dead code.

In a self-contained single-file publish, `libcoreclr.so` is bundled inside the host binary and does not exist on the filesystem. Without the resolver, the P/Invoke falls through to the OS dynamic linker which cannot find it.

## Fix

This PR registers an `AssemblyLoadContext.Default.ResolvingUnmanagedDll` handler in `Program.Main` (before TUI initialization, only on non-Windows) that returns `(IntPtr)(-1)` for `libcoreclr.so`, telling the runtime to resolve it from the current process.

This is a **temporary workaround** in MCC. The proper upstream fix has been submitted to Consolonia: https://github.com/Consolonia/Consolonia/pull/605 (changes `#if NET6_0` to `#if NET6_0_OR_GREATER`). Once that fix is released in a new Consolonia NuGet package, this workaround can be removed.

## Verification

Tested on a QEMU-emulated Debian 13 (Trixie) ARM64 VM with `dotnet publish -r linux-arm64 --self-contained=true`:

- **Before**: `DllNotFoundException` crash on TUI startup
- **After**: TUI starts successfully

## Changes

- `MinecraftClient/Program.cs`: added `InstallCursesNativeResolver()` method and a call before the TUI mode branch

Made with [Cursor](https://cursor.com)