### PR TITLE
fix: resolve AutoRelog reconnect errors (#3036)

### DIFF
--- a/MinecraftClient/ChatBots/AutoRelog.cs
+++ b/MinecraftClient/ChatBots/AutoRelog.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using MinecraftClient.Scripting;
 using Tomlet.Attributes;
 
@@ -95,6 +95,11 @@ namespace MinecraftClient.ChatBots
             _Initialize();
         }
 
+        public override void AfterGameJoined()
+        {
+            Configs._BotRecoAttempts = 0;
+        }
+
         private void _Initialize()
         {
             McClient.ReconnectionAttemptsLeft = Config.Retries;
@@ -144,10 +149,17 @@ namespace MinecraftClient.ChatBots
         {
             double delay = random.NextDouble() * (Config.Delay.max - Config.Delay.min) + Config.Delay.min;
             LogDebugToConsole(string.Format(string.IsNullOrEmpty(msg) ? Translations.bot_autoRelog_reconnect_always : Translations.bot_autoRelog_reconnect, msg));
-            
-            // TODO: Change this translation string to add the retries left text
-            LogToConsole(string.Format(Translations.bot_autoRelog_wait, delay) + $" ({Config.Retries - Configs._BotRecoAttempts} retries left)");
-            ReconnectToTheServer(Config.Retries - Configs._BotRecoAttempts, (int)Math.Floor(delay), true);
+
+            int retriesLeft = Config.Retries - Configs._BotRecoAttempts;
+            if (retriesLeft < 0)
+                retriesLeft = 0;
+
+            string retriesDisplay = Config.Retries == int.MaxValue
+                ? Translations.bot_autoRelog_retries_unlimited
+                : retriesLeft.ToString();
+
+            LogToConsole(string.Format(Translations.bot_autoRelog_wait_with_retries, delay, retriesDisplay));
+            ReconnectToTheServer(retriesLeft, (int)Math.Floor(delay), true);
         }
 
         public static bool OnDisconnectStatic(DisconnectReason reason, string message)

--- a/MinecraftClient/McClient.cs
+++ b/MinecraftClient/McClient.cs
@@ -1579,6 +1579,12 @@ namespace MinecraftClient
             if (String.IsNullOrEmpty(text))
                 return;
 
+            if (!CanSendMessage)
+            {
+                Log.Warn(Translations.mcc_send_text_not_connected);
+                return;
+            }
+
             int maxLength = handler.GetMaxChatMessageLength();
 
             lock (chatQueue)

--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -324,6 +324,12 @@ namespace MinecraftClient.Protocol.Handlers
             catch (NullReferenceException)
             {
             }
+            catch (SocketException)
+            {
+            }
+            catch (System.IO.IOException)
+            {
+            }
 
             if (cancelToken.IsCancellationRequested)
                 return;

--- a/MinecraftClient/Resources/Translations/Translations.Designer.cs
+++ b/MinecraftClient/Resources/Translations/Translations.Designer.cs
@@ -898,6 +898,24 @@ namespace MinecraftClient {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Waiting {0:0.000} seconds before reconnecting... ({1} retries left).
+        /// </summary>
+        internal static string bot_autoRelog_wait_with_retries {
+            get {
+                return ResourceManager.GetString("bot.autoRelog.wait_with_retries", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to unlimited.
+        /// </summary>
+        internal static string bot_autoRelog_retries_unlimited {
+            get {
+                return ResourceManager.GetString("bot.autoRelog.retries_unlimited", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to File not found: &apos;{0}&apos;.
         /// </summary>
         internal static string bot_autoRespond_file_not_found {
@@ -6155,6 +6173,15 @@ namespace MinecraftClient {
         internal static string mcc_restart {
             get {
                 return ResourceManager.GetString("mcc.restart", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot send text: not connected to a server..
+        /// </summary>
+        internal static string mcc_send_text_not_connected {
+            get {
+                return ResourceManager.GetString("mcc.send_text_not_connected", resourceCulture);
             }
         }
         

--- a/MinecraftClient/Resources/Translations/Translations.resx
+++ b/MinecraftClient/Resources/Translations/Translations.resx
@@ -394,6 +394,12 @@
   <data name="bot.autoRelog.wait" xml:space="preserve">
     <value>Waiting {0:0.000} seconds before reconnecting...</value>
   </data>
+  <data name="bot.autoRelog.wait_with_retries" xml:space="preserve">
+    <value>Waiting {0:0.000} seconds before reconnecting... ({1} retries left)</value>
+  </data>
+  <data name="bot.autoRelog.retries_unlimited" xml:space="preserve">
+    <value>unlimited</value>
+  </data>
   <data name="bot.autoRespond.file_not_found" xml:space="preserve">
     <value>File not found: '{0}'</value>
   </data>
@@ -2057,6 +2063,9 @@ Type '{0}quit' to leave the server.</value>
   </data>
   <data name="mcc.restart" xml:space="preserve">
     <value>Restarting Minecraft Console Client...</value>
+  </data>
+  <data name="mcc.send_text_not_connected" xml:space="preserve">
+    <value>Cannot send text: not connected to a server.</value>
   </data>
   <data name="mcc.restart_delay" xml:space="preserve">
     <value>Waiting {0} seconds before restarting...</value>


### PR DESCRIPTION
## Summary

Fixes #3036

- **Reset retry counter on successful join**: `_BotRecoAttempts` was never reset after a successful reconnect, causing stale state to accumulate across sessions.
- **Fix huge retry count display**: When `Retries = -1` (infinite), the value was converted to `int.MaxValue` internally, and the log message displayed ~2147483647 retries left. Now shows "unlimited" instead.
- **Guard `SendText` against post-disconnect calls**: `ScriptScheduler` (and other bots) could invoke `SendText` after the connection was torn down, hitting a `NullReferenceException` on `handler.GetMaxChatMessageLength()`. Added a `CanSendMessage` early-return guard.
- **Catch `SocketException`/`IOException` in Protocol18 Updater thread**: The `HandlePacket` catch block intentionally re-throws `SocketException`, but the `Updater` method did not catch it, resulting in an unhandled exception crash. Now caught so the thread exits gracefully into `OnConnectionLost`.

## Test plan

- [ ] Configure AutoRelog with `Retries = -1` (infinite), connect to a server, verify log shows "unlimited retries left"
- [ ] Configure AutoRelog with `Retries = 3`, get kicked, verify retries count down correctly from 3
- [ ] After a successful reconnect, verify the retry counter resets (disconnect again and observe it starts from the configured value)
- [ ] Enable ScriptScheduler with a `send` action on interval, disconnect from server, verify no `NullReferenceException` in logs
- [ ] Kill the server mid-session, verify no unhandled `SocketException` crash and that MCC transitions to reconnect/offline prompt gracefully

Made with [Cursor](https://cursor.com)