### PR TITLE
fix: correct /bed translation typo

### DIFF
--- a/MinecraftClient/Resources/Translations/Translations.Designer.cs
+++ b/MinecraftClient/Resources/Translations/Translations.Designer.cs
@@ -2718,7 +2718,7 @@ namespace MinecraftClient {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Found a bet at (X: {0:0.0}, Y: {1:0.0}, Z: {2:0.0})..
+        ///   Looks up a localized string similar to Found a bed at (X: {0:0.0}, Y: {1:0.0}, Z: {2:0.0})..
         /// </summary>
         internal static string cmd_bed_found_a_bed_at {
             get {

--- a/MinecraftClient/Resources/Translations/Translations.resx
+++ b/MinecraftClient/Resources/Translations/Translations.resx
@@ -988,7 +988,7 @@ Some messages won't be properly printed without this file.</value>
     <value>Failed to reach the bed position (X: {0:0.0}, Y: {1:0.0}, Z: {2:0.0}) in time (30 seconds). Giving up!</value>
   </data>
   <data name="cmd.bed.found_a_bed_at" xml:space="preserve">
-    <value>Found a bet at (X: {0:0.0}, Y: {1:0.0}, Z: {2:0.0}).</value>
+    <value>Found a bed at (X: {0:0.0}, Y: {1:0.0}, Z: {2:0.0}).</value>
   </data>
   <data name="cmd.bed.in" xml:space="preserve">
     <value>Succesfully laid in bed!</value>


### PR DESCRIPTION
## Summary
- correct the `/bed` translation string so MCC reports `Found a bed` instead of `Found a bet`
- update the tracked generated translation designer comment to match the resource value

## Validation
- verified the `/bed` command uses `Translations.cmd_bed_found_a_bed_at` in `MinecraftClient/Commands/Bed.cs`
- verified there are no remaining `Found a bet` matches in the repo
- `dotnet build MinecraftClient.sln -c Release` could not run in this environment because `dotnet` is not installed