### PR TITLE
Fix NullReferenceException in StartConsoleSession with BasicIO

### DIFF
--- a/MinecraftClient/McClient.cs
+++ b/MinecraftClient/McClient.cs
@@ -525,6 +525,9 @@ namespace MinecraftClient
 
         private void StartConsoleSession()
         {
+            if (ConsoleIO.Backend is null)
+                return;
+
             cmdprompt = new CancellationTokenSource();
 
             if (!consoleReadThreadOwned)


### PR DESCRIPTION
### Problem

When MCC runs in BasicIO mode (used for headless/unattended automation with `CREATE_NO_WINDOW`), `ConsoleIO.Backend` remains `null` because `ClassicConsoleBackend` is never initialized. After a successful server join, `StartConsoleSession()` unconditionally dereferences the null backend, causing:

```
NullReferenceException: Object reference not set to an instance of an object.
   at MinecraftClient.McClient.StartConsoleSession()
```

This makes BasicIO mode unusable for automated/batch deployments where zero visible console windows are desired.

### Fix

Add an early-return guard when `ConsoleIO.Backend` is `null` at the top of `StartConsoleSession()`. This is safe because BasicIO mode does not require interactive console input handling — `StopConsoleSession()` is already safe via `consoleHandlersAttached` remaining `false`.

### Testing

- Built and published for `win-x64` (self-contained single-file)
- Launched with `BasicIO` + `CREATE_NO_WINDOW` — process starts, connects to a Minecraft server, AutoFishing, ScriptScheduler, and AutoRelog all work correctly without any crash
- No regression for normal interactive console mode (ClassicConsoleBackend is initialized as before)