### PR TITLE
bugfix: Fix Auto Relog not working in certain scenarios

### DIFF
--- a/MinecraftClient/ChatBots/AutoRelog.cs
+++ b/MinecraftClient/ChatBots/AutoRelog.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using MinecraftClient.Scripting;
 using Tomlet.Attributes;
 
@@ -77,7 +78,9 @@ namespace MinecraftClient.ChatBots
             }
         }
 
-        private static readonly Random random = new();
+        private static readonly Lock s_reconnectStateLock = new();
+        private static readonly TimeSpan s_stableJoinBeforeRetryReset = TimeSpan.FromSeconds(60);
+        private static DateTime? s_lastJoinUtc;
 
         /// <summary>
         /// This bot automatically re-join the server if kick message contains predefined string
@@ -97,7 +100,13 @@ namespace MinecraftClient.ChatBots
 
         public override void AfterGameJoined()
         {
-            Configs._BotRecoAttempts = 0;
+            lock (s_reconnectStateLock)
+                s_lastJoinUtc = DateTime.UtcNow;
+        }
+
+        public override void Update()
+        {
+            ResetRetriesAfterStableJoin();
         }
 
         private void _Initialize()
@@ -115,7 +124,11 @@ namespace MinecraftClient.ChatBots
             {
                 LogDebugToConsole(Translations.bot_autoRelog_ignore_user_logout);
             }
-            else if (Config.Retries < 0 || Configs._BotRecoAttempts < Config.Retries)
+            else if (Program.HasRestartPendingForAnotherThread)
+            {
+                return true;
+            }
+            else if (CanReconnect())
             {
                 message = GetVerbatim(message);
                 string comp = message.ToLower();
@@ -124,18 +137,14 @@ namespace MinecraftClient.ChatBots
 
                 if (Config.Ignore_Kick_Message)
                 {
-                    Configs._BotRecoAttempts++;
-                    LaunchDelayedReconnection(null);
-                    return true;
+                    return LaunchDelayedReconnection(null);
                 }
 
                 foreach (string msg in Config.Kick_Messages)
                 {
                     if (comp.Contains(msg))
                     {
-                        Configs._BotRecoAttempts++;
-                        LaunchDelayedReconnection(msg);
-                        return true;
+                        return LaunchDelayedReconnection(msg);
                     }
                 }
 
@@ -145,21 +154,83 @@ namespace MinecraftClient.ChatBots
             return false;
         }
 
-        private void LaunchDelayedReconnection(string? msg)
+        private static bool CanReconnect()
         {
-            double delay = random.NextDouble() * (Config.Delay.max - Config.Delay.min) + Config.Delay.min;
+            lock (s_reconnectStateLock)
+                return Config.Retries < 0 || Configs._BotRecoAttempts < Config.Retries;
+        }
+
+        private static void ResetRetriesAfterStableJoin()
+        {
+            lock (s_reconnectStateLock)
+            {
+                if (Configs._BotRecoAttempts <= 0 || s_lastJoinUtc is not DateTime lastJoinUtc)
+                    return;
+
+                if (DateTime.UtcNow - lastJoinUtc < s_stableJoinBeforeRetryReset)
+                    return;
+
+                Configs._BotRecoAttempts = 0;
+                s_lastJoinUtc = null;
+                McClient.ReconnectionAttemptsLeft = Config.Retries;
+            }
+        }
+
+        private static bool TryConsumeReconnectAttempt(out int retriesLeft)
+        {
+            lock (s_reconnectStateLock)
+            {
+                bool unlimitedRetries = HasUnlimitedRetries();
+                if (!unlimitedRetries && Configs._BotRecoAttempts >= Config.Retries)
+                {
+                    retriesLeft = 0;
+                    return false;
+                }
+
+                Configs._BotRecoAttempts++;
+                s_lastJoinUtc = null;
+                retriesLeft = unlimitedRetries ? int.MaxValue : Config.Retries - Configs._BotRecoAttempts;
+                if (retriesLeft < 0)
+                    retriesLeft = 0;
+                return true;
+            }
+        }
+
+        private static bool HasUnlimitedRetries()
+        {
+            return Config.Retries < 0 || Config.Retries == int.MaxValue;
+        }
+
+        private static void RollBackReconnectAttempt()
+        {
+            lock (s_reconnectStateLock)
+            {
+                if (Configs._BotRecoAttempts > 0)
+                    Configs._BotRecoAttempts--;
+            }
+        }
+
+        private bool LaunchDelayedReconnection(string? msg)
+        {
+            if (!TryConsumeReconnectAttempt(out int retriesLeft))
+                return false;
+
+            double delay = Random.Shared.NextDouble() * (Config.Delay.max - Config.Delay.min) + Config.Delay.min;
             LogDebugToConsole(string.Format(string.IsNullOrEmpty(msg) ? Translations.bot_autoRelog_reconnect_always : Translations.bot_autoRelog_reconnect, msg));
 
-            int retriesLeft = Config.Retries - Configs._BotRecoAttempts;
-            if (retriesLeft < 0)
-                retriesLeft = 0;
-
-            string retriesDisplay = Config.Retries == int.MaxValue
+            string retriesDisplay = HasUnlimitedRetries()
                 ? Translations.bot_autoRelog_retries_unlimited
                 : retriesLeft.ToString();
 
-            LogToConsole(string.Format(Translations.bot_autoRelog_wait_with_retries, delay, retriesDisplay));
-            ReconnectToTheServer(retriesLeft, (int)Math.Floor(delay), true);
+            McClient.ReconnectionAttemptsLeft = retriesLeft;
+            if (Program.TryRestart((int)Math.Floor(delay), true))
+            {
+                LogToConsole(string.Format(Translations.bot_autoRelog_wait_with_retries, delay, retriesDisplay));
+                return true;
+            }
+
+            RollBackReconnectAttempt();
+            return true;
         }
 
         public static bool OnDisconnectStatic(DisconnectReason reason, string message)

--- a/MinecraftClient/Program.cs
+++ b/MinecraftClient/Program.cs
@@ -900,11 +900,24 @@ namespace MinecraftClient
         /// <param name="keepAccountAndServerSettings">Optional, keep account and server settings</param>
         public static void Restart(int delaySeconds = 0, bool keepAccountAndServerSettings = false)
         {
+            TryRestart(delaySeconds, keepAccountAndServerSettings);
+        }
+
+        internal static bool HasRestartPendingForAnotherThread
+        {
+            get
+            {
+                lock (_restartLock)
+                    return HasRestartPendingForAnotherThreadNoLock();
+            }
+        }
+
+        internal static bool TryRestart(int delaySeconds = 0, bool keepAccountAndServerSettings = false)
+        {
             lock (_restartLock)
             {
-                if (_restartThread is not null && _restartThread.IsAlive
-                    && _restartThread != Thread.CurrentThread)
-                    return;
+                if (HasRestartPendingForAnotherThreadNoLock())
+                    return false;
 
                 ConsoleIO.Backend?.StopReadThread();
                 var thread = new Thread(new ThreadStart(delegate
@@ -938,7 +951,15 @@ namespace MinecraftClient
                 }));
                 _restartThread = thread;
                 thread.Start();
+                return true;
             }
+        }
+
+        private static bool HasRestartPendingForAnotherThreadNoLock()
+        {
+            return _restartThread is not null
+                && _restartThread.IsAlive
+                && _restartThread != Thread.CurrentThread;
         }
 
         public static void DoExit(int exitcode = 0)


### PR DESCRIPTION
This pull request refactors and improves the auto-relogin logic in the `AutoRelog` chat bot, making reconnection attempts more robust and thread-safe. It introduces a lock to synchronize reconnect state, adds logic to reset retries after a stable join, and prevents overlapping restarts. Additionally, it refactors the reconnection attempt logic to better handle retry limits and delays.

**AutoRelog reconnection improvements:**

* Added a lock (`s_reconnectStateLock`) and related state variables to synchronize reconnect attempts and track the last successful join time, improving thread safety and reliability.
* Implemented logic to reset the retry counter (`Configs._BotRecoAttempts`) if the bot has been connected for a stable period (60 seconds), reducing unnecessary retry exhaustion. [[1]](diffhunk://#diff-7e4cf5428682317c8091e761ae82436a40e2634cc2971fc603357964fa175bdfL100-R109) [[2]](diffhunk://#diff-7e4cf5428682317c8091e761ae82436a40e2634cc2971fc603357964fa175bdfL148-R233)
* Refactored reconnection logic to use helper methods (`CanReconnect`, `TryConsumeReconnectAttempt`, `RollBackReconnectAttempt`), ensuring retries are only consumed when appropriate and rolled back on failure.
* Modified the way reconnection attempts are launched, now returning a boolean to indicate if a reconnection was scheduled, and updating retry counters and client state accordingly. [[1]](diffhunk://#diff-7e4cf5428682317c8091e761ae82436a40e2634cc2971fc603357964fa175bdfL127-R147) [[2]](diffhunk://#diff-7e4cf5428682317c8091e761ae82436a40e2634cc2971fc603357964fa175bdfL148-R233)

**Program restart coordination:**

* Added `HasRestartPendingForAnotherThread` and `TryRestart` methods in `Program.cs` to prevent multiple concurrent restart attempts and expose restart state to bots, improving overall stability during reconnects. [[1]](diffhunk://#diff-bc4c4002195fb77a72ce7406e8379ea301ba221d67a5c2f5f846e0c04ee59838R902-R920) [[2]](diffhunk://#diff-bc4c4002195fb77a72ce7406e8379ea301ba221d67a5c2f5f846e0c04ee59838R954-R964)

These changes make the auto-relogin feature more reliable, especially in multi-threaded scenarios, and help avoid exhausting reconnect attempts unnecessarily.