### PR TITLE
chores: Revert inventory sync changes

### DIFF
--- a/MinecraftClient/McClient.cs
+++ b/MinecraftClient/McClient.cs
@@ -2062,38 +2062,6 @@ namespace MinecraftClient
             };
         }
 
-        private static bool TryGetMirroredPlayerInventoryRange(Container inventory, out int firstWindowSlot, out int lastWindowSlot)
-        {
-            firstWindowSlot = -1;
-            lastWindowSlot = -1;
-
-            if (inventory.Type == ContainerType.PlayerInventory)
-                return false;
-
-            const int mirroredPlayerInventorySlotCount = 36;
-            int slotCount = inventory.Type.SlotCount();
-            if (slotCount < mirroredPlayerInventorySlotCount)
-                return false;
-
-            firstWindowSlot = slotCount - mirroredPlayerInventorySlotCount;
-            lastWindowSlot = slotCount - 1;
-            return true;
-        }
-
-        private static bool TryGetMirroredPlayerInventorySlot(Container inventory, int windowSlot, out int playerInventorySlot)
-        {
-            playerInventorySlot = -1;
-
-            if (!TryGetMirroredPlayerInventoryRange(inventory, out int firstWindowSlot, out int lastWindowSlot))
-                return false;
-
-            if (windowSlot < firstWindowSlot || windowSlot > lastWindowSlot)
-                return false;
-
-            playerInventorySlot = windowSlot - firstWindowSlot + 9;
-            return true;
-        }
-
         private static bool AreSameInventorySlot(Item? left, Item? right)
         {
             if (left is null || left.IsEmpty)
@@ -2123,27 +2091,6 @@ namespace MinecraftClient
                 playerInventory.Items[playerInventorySlot] = item;
 
             return true;
-        }
-
-        private bool SyncPlayerInventorySlotFromWindow(Container inventory, int windowSlot)
-        {
-            if (!TryGetMirroredPlayerInventorySlot(inventory, windowSlot, out int playerInventorySlot))
-                return false;
-
-            inventory.Items.TryGetValue(windowSlot, out Item? item);
-            return SetPlayerInventorySlot(playerInventorySlot, item);
-        }
-
-        private bool SyncPlayerInventorySlotsFromWindow(Container inventory)
-        {
-            if (!TryGetMirroredPlayerInventoryRange(inventory, out int firstWindowSlot, out int lastWindowSlot))
-                return false;
-
-            bool changed = false;
-            for (int windowSlot = firstWindowSlot; windowSlot <= lastWindowSlot; windowSlot++)
-                changed |= SyncPlayerInventorySlotFromWindow(inventory, windowSlot);
-
-            return changed;
         }
 
         /// <summary>
@@ -2872,8 +2819,6 @@ namespace MinecraftClient
                         changedSlots.Add(new Tuple<short, Item?>((short)slotId, null));
                         break;
                 }
-
-                SyncPlayerInventorySlotsFromWindow(inventory);
             }
 
             return handler.SendWindowAction(windowId, slotId, action, item, changedSlots, inventories[windowId].StateID);
@@ -3915,9 +3860,6 @@ namespace MinecraftClient
             {
                 inventories[inventoryID].Items = itemList;
                 inventories[inventoryID].StateID = stateId;
-                bool playerInventoryChanged = SyncPlayerInventorySlotsFromWindow(inventories[inventoryID]);
-                if (playerInventoryChanged)
-                    DispatchBotEvent(bot => bot.OnInventoryUpdate(0));
                 DispatchBotEvent(bot => bot.OnInventoryUpdate(inventoryID));
             }
         }
@@ -3958,9 +3900,6 @@ namespace MinecraftClient
                             inventories[inventoryID].Items.Remove(slotID);
                     }
                     else inventories[inventoryID].Items[slotID] = item;
-
-                    if (SyncPlayerInventorySlotFromWindow(inventories[inventoryID], slotID))
-                        DispatchBotEvent(bot => bot.OnInventoryUpdate(0));
                 }
             }
             DispatchBotEvent(bot => bot.OnInventoryUpdate(inventoryID));


### PR DESCRIPTION
Reverts inventory mirroring until this issue is debugged manually and then fixed.