### PR TITLE
bugfix: Protocol gap fixes (Entity Effect Duration, Villager Trading on 1.20.6+, Enchanting effected)

### DIFF
--- a/MinecraftClient/Protocol/Handlers/DataTypes.cs
+++ b/MinecraftClient/Protocol/Handlers/DataTypes.cs
@@ -1396,12 +1396,14 @@ namespace MinecraftClient.Protocol.Handlers
         /// <returns>The item that was read or NULL for an empty slot</returns>
         public VillagerTrade ReadNextTrade(Queue<byte> cache, ItemPalette itemPalette)
         {
-            Item inputItem1 = ReadNextItemSlot(cache, itemPalette)!;
+            Item inputItem1 = ReadNextTradeCost(cache, itemPalette)!;
             Item outputItem = ReadNextItemSlot(cache, itemPalette)!;
 
             Item? inputItem2 = null;
 
-            if (protocolversion >= Protocol18Handler.MC_1_19_3_Version)
+            if (protocolversion >= Protocol18Handler.MC_1_20_6_Version)
+                inputItem2 = ReadNextOptionalTradeCost(cache, itemPalette);
+            else if (protocolversion >= Protocol18Handler.MC_1_19_3_Version)
                 inputItem2 = ReadNextItemSlot(cache, itemPalette);
             else
             {
@@ -1418,6 +1420,40 @@ namespace MinecraftClient.Protocol.Handlers
             int demand = ReadNextInt(cache);
             return new VillagerTrade(inputItem1, outputItem, inputItem2, tradeDisabled, numberOfTradeUses,
                 maximumNumberOfTradeUses, xp, specialPrice, priceMultiplier, demand);
+        }
+
+        private Item? ReadNextTradeCost(Queue<byte> cache, ItemPalette itemPalette)
+        {
+            if (protocolversion < Protocol18Handler.MC_1_20_6_Version)
+                return ReadNextItemSlot(cache, itemPalette);
+
+            var itemId = ReadNextVarInt(cache);
+            var itemCount = ReadNextVarInt(cache);
+            var item = new Item(itemPalette.FromId(itemId), itemCount, null);
+            var componentCount = ReadNextVarInt(cache);
+
+            if (componentCount > 0)
+            {
+                var structuredComponentHandler = new StructuredComponentsHandler(protocolversion, this, itemPalette);
+                var components = new List<StructuredComponent>(componentCount);
+                for (var i = 0; i < componentCount; i++)
+                {
+                    var componentTypeId = ReadNextVarInt(cache);
+                    components.Add(structuredComponentHandler.Parse(componentTypeId, cache));
+                }
+
+                item.Components = components;
+            }
+
+            return item;
+        }
+
+        private Item? ReadNextOptionalTradeCost(Queue<byte> cache, ItemPalette itemPalette)
+        {
+            if (!ReadNextBool(cache))
+                return null;
+
+            return ReadNextTradeCost(cache, itemPalette);
         }
 
         public string ReadNextChat(Queue<byte> cache)

--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -2104,12 +2104,9 @@ namespace MinecraftClient.Protocol.Handlers
 
                     break;
                 case PacketTypesIn.ChangeGameState:
-                    if (protocolVersion >= MC_1_15_2_Version)
-                    {
-                        var reason = dataTypes.ReadNextByte(packetData);
-                        var state = dataTypes.ReadNextFloat(packetData);
-                        handler.OnGameEvent(reason, state);
-                    }
+                    var reason = dataTypes.ReadNextByte(packetData);
+                    var state = dataTypes.ReadNextFloat(packetData);
+                    handler.OnGameEvent(reason, state);
 
                     break;
                 case PacketTypesIn.PlayerInfo:
@@ -2337,6 +2334,11 @@ namespace MinecraftClient.Protocol.Handlers
                         handler.OnPlayerLeave(playerUuid);
                     }
 
+                    break;
+                case PacketTypesIn.PlayerListHeaderAndFooter:
+                    handler.OnTabListHeaderAndFooter(
+                        dataTypes.ReadNextChat(packetData),
+                        dataTypes.ReadNextChat(packetData));
                     break;
                 case PacketTypesIn.TabComplete:
                     var oldTransactionId = autocomplete_transaction_id;
@@ -2605,7 +2607,9 @@ namespace MinecraftClient.Protocol.Handlers
                         if (Enum.IsDefined(typeof(Effects), effectId))
                         {
                             var effect = (Effects)effectId;
-                            var amplifier = dataTypes.ReadNextByte(packetData);
+                            var amplifier = protocolVersion >= MC_1_20_6_Version
+                                ? dataTypes.ReadNextVarInt(packetData)
+                                : dataTypes.ReadNextByte(packetData);
                             var duration = dataTypes.ReadNextVarInt(packetData);
                             var flags = dataTypes.ReadNextByte(packetData);
                             var hasFactorData = false;
@@ -3088,7 +3092,10 @@ namespace MinecraftClient.Protocol.Handlers
                     }
                 case PacketTypesIn.HeldItemChange:
                 case PacketTypesIn.SetHeldSlot:
-                    handler.OnHeldItemChange(dataTypes.ReadNextByte(packetData)); // Slot
+                    var heldSlot = protocolVersion >= MC_1_21_4_Version
+                        ? dataTypes.ReadNextVarInt(packetData)
+                        : dataTypes.ReadNextByte(packetData);
+                    handler.OnHeldItemChange((byte)heldSlot);
                     break;
                 case PacketTypesIn.ScoreboardObjective:
                     var objectiveName = dataTypes.ReadNextString(packetData);
@@ -6082,11 +6089,18 @@ namespace MinecraftClient.Protocol.Handlers
         {
             try
             {
-                var packet = new List<byte>
+                List<byte> packet = new();
+                if (protocolVersion >= MC_1_20_6_Version)
                 {
-                    (byte)windowId,
-                    (byte)buttonId
-                };
+                    packet.AddRange(DataTypes.GetVarInt(windowId));
+                    packet.AddRange(DataTypes.GetVarInt(buttonId));
+                }
+                else
+                {
+                    packet.Add((byte)windowId);
+                    packet.Add((byte)buttonId);
+                }
+
                 SendPacket(PacketTypesOut.ClickWindowButton, packet);
                 return true;
             }


### PR DESCRIPTION
Fix protocol gaps for newer Minecraft releases.

This updates villager trade parsing for 1.20.6+, reads tab list header/footer packets, handles the newer `EntityEffect` amplifier and held-slot packet shapes, and sends container button
clicks in the format newer servers expect.

Verified the changes on 1.20.4, 1.20.6, and 1.21.4 with local servers. The affected paths now join cleanly, parse effects, open villager and enchanting containers, and send the expected
clicks without protocol errors.
