### PR TITLE
bugfix: restore full color depth for hex color codes (§#RRGGBB)

### DIFF
--- a/MinecraftClient/ClassicConsoleBackend.cs
+++ b/MinecraftClient/ClassicConsoleBackend.cs
@@ -64,7 +64,7 @@ namespace MinecraftClient
                 byte r = (byte)((HexVal(hex[0]) << 4) | HexVal(hex[1]));
                 byte g = (byte)((HexVal(hex[2]) << 4) | HexVal(hex[3]));
                 byte b = (byte)((HexVal(hex[4]) << 4) | HexVal(hex[5]));
-                return $"§{NearestMcColor(r, g, b)}";
+                return ColorHelper.GetColorEscapeCode(r, g, b, foreground: true);
             });
         }
 


### PR DESCRIPTION
Fixes #3146.

After PR #3143, hex colors like `#ff8800` got snapped to the nearest standard Minecraft shade. So gradients and server-branded text lost most of their range. The problem was in `ResolveHexColors`, it mapped every `§#RRGGBB` to one of 16 colors via `NearestMcColor`.

The fix is a one-line swap: `ColorHelper.GetColorEscapeCode` instead of `NearestMcColor`. It picks the right ANSI sequence for whatever `ConsoleColorMode` the user has set - 24-bit when available, falling back to 8-bit or 4-bit.

## Test

```
tellraw mcc_color_test [
  {"text":"H","color":"#ff8800"},
  {"text":"E","color":"#ff9900"},
  {"text":"L","color":"#ffaa00"},
  {"text":"L","color":"#ffbb00"},
  {"text":"O","color":"#ffcc00"},
  {"text":"!","color":"#ffdd00"}
]

tellraw mcc_color_test {"text":"Lime green!","color":"#aaff00"}

tellraw mcc_color_test [
  {"text":"Red: ","color":"red"},
  {"text":"HexOrange: ","color":"#ff8800"},
  {"text":"HexCyan: ","color":"#00ccff"},
  {"text":" Reset"}
]
```

<img width="553" height="115" alt="image" src="https://github.com/user-attachments/assets/991d3975-226d-43c0-aefb-9d2cd05685d0" />
