### PR TITLE
bugfix: handle null/empty profile name in ProfileComponent serialization

### DIFF
--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/ProfileComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Components/1_20_6/ProfileComponent.cs
@@ -112,12 +112,7 @@ public class ProfileComponent(DataTypes dataTypes, ItemPalette itemPalette, SubC
 
         data.AddRange(DataTypes.GetBool(HasName));
         if (HasName)
-        {
-            if (string.IsNullOrEmpty(Name))
-                throw new NullReferenceException("Can't serialize the ProfileComponent because the Name is null/empty!");
-
-            data.AddRange(DataTypes.GetString(Name));
-        }
+            data.AddRange(DataTypes.GetString(Name ?? ""));
 
         data.AddRange(DataTypes.GetBool(HasUniqueId));
         if (HasUniqueId)
@@ -140,22 +135,14 @@ public class ProfileComponent(DataTypes dataTypes, ItemPalette itemPalette, SubC
             if (!HasUniqueId)
                 throw new NullReferenceException("Can't serialize the ProfileComponent because a full profile requires a UUID!");
 
-            if (!HasName || string.IsNullOrEmpty(Name))
-                throw new NullReferenceException("Can't serialize the ProfileComponent because a full profile requires a name!");
-
             data.AddRange(DataTypes.GetUUID(Uuid));
-            data.AddRange(DataTypes.GetString(Name));
+            data.AddRange(DataTypes.GetString(Name ?? ""));
         }
         else
         {
             data.AddRange(DataTypes.GetBool(HasName));
             if (HasName)
-            {
-                if (string.IsNullOrEmpty(Name))
-                    throw new NullReferenceException("Can't serialize the ProfileComponent because HasName is true, but the Name is null/empty!");
-
-                data.AddRange(DataTypes.GetString(Name));
-            }
+                data.AddRange(DataTypes.GetString(Name ?? ""));
 
             data.AddRange(DataTypes.GetBool(HasUniqueId));
             if (HasUniqueId)


### PR DESCRIPTION
The ProfileComponent serialization path throws a NullReferenceException when the player name field is null or empty. This crashes the client when it receives a player head item with an incomplete profile component, which some servers use for custom inventory icons.

The fix replaces the three throw statements with a fallback to an empty string via `Name ?? ""`. The Minecraft protocol allows empty names in the profile component, so this produces valid wire data.

Fixes #3145