### PR TITLE
feat(inventory): expose NBT/component data in inventory MCP tools

### DIFF
--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Core/StructuredComponent.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Core/StructuredComponent.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 using MinecraftClient.Inventory.ItemPalettes;
 
 namespace MinecraftClient.Protocol.Handlers.StructuredComponents.Core;
@@ -12,7 +13,14 @@ public abstract class StructuredComponent(DataTypes dataTypes, ItemPalette itemP
     /// <summary>
     /// The registry type ID assigned during parsing, used for round-trip serialization.
     /// </summary>
+    [JsonIgnore]
     public int TypeId { get; set; } = -1;
+
+    /// <summary>
+    /// The registry name assigned during parsing (e.g. "minecraft:custom_data"), used for NBT serialization.
+    /// </summary>
+    [JsonIgnore]
+    public string ComponentName { get; set; } = string.Empty;
 
     public abstract void Parse(Queue<byte> data);
     public abstract Queue<byte> Serialize();

--- a/MinecraftClient/Protocol/Handlers/StructuredComponents/Core/StructuredComponentRegistry.cs
+++ b/MinecraftClient/Protocol/Handlers/StructuredComponents/Core/StructuredComponentRegistry.cs
@@ -37,6 +37,7 @@ public abstract class StructuredComponentRegistry(DataTypes dataTypes, ItemPalet
                     ?? throw new InvalidOperationException($"Could not instantiate a parser for a structured component type {name}");
 
                 component.TypeId = id;
+                component.ComponentName = name;
                 component.Parse(data);
                 return component;
             }

--- a/MinecraftClient/Scripting/MccGameApi.cs
+++ b/MinecraftClient/Scripting/MccGameApi.cs
@@ -795,7 +795,8 @@ public sealed class MccGameApi
                 {
                     Slot = item.Key,
                     Type = item.Value.Type.ToString(),
-                    Count = item.Value.Count
+                    Count = item.Value.Count,
+                    Nbt = MccGameCommon.BuildNbt(item.Value)
                 })
                 .ToArray();
 
@@ -856,7 +857,8 @@ public sealed class MccGameApi
                                 TypeLabel = pair.Value.GetTypeString(),
                                 Count = pair.Value.Count,
                                 IsPlayerInventory = entry.Key == 0,
-                                HotbarSlot = isHotbar ? hotbar + 1 : null
+                                HotbarSlot = isHotbar ? hotbar + 1 : null,
+                                Nbt = MccGameCommon.BuildNbt(pair.Value)
                             };
                         });
                 })

--- a/MinecraftClient/Scripting/MccGameCommon.cs
+++ b/MinecraftClient/Scripting/MccGameCommon.cs
@@ -35,6 +35,7 @@ public sealed class MccItemStackSnapshot
 {
     public required string Type { get; init; }
     public required int Count { get; init; }
+    public Dictionary<string, object>? Nbt { get; init; }
 }
 
 /// <summary>
@@ -177,8 +178,24 @@ public static class MccGameCommon
         return new MccItemStackSnapshot
         {
             Type = item.Type.ToString(),
-            Count = item.Count
+            Count = item.Count,
+            Nbt = BuildNbt(item)
         };
+    }
+
+    public static Dictionary<string, object>? BuildNbt(Item item)
+    {
+        if (item.Components is { Count: > 0 })
+        {
+            return item.Components
+                .Where(c => !string.IsNullOrEmpty(c.ComponentName))
+                .ToDictionary(
+                    c => c.ComponentName,
+                    c => (object)System.Text.Json.JsonSerializer.SerializeToElement(c, c.GetType())
+                );
+        }
+
+        return item.NBT is { Count: > 0 } ? item.NBT : null;
     }
 
     public static bool TryParseBlockQuery(string? query, out int? blockId, out int? blockMeta)

--- a/MinecraftClient/Scripting/MccGameModels.cs
+++ b/MinecraftClient/Scripting/MccGameModels.cs
@@ -216,6 +216,7 @@ public sealed class MccInventorySnapshotSlot
     public required int Slot { get; init; }
     public required string Type { get; init; }
     public required int Count { get; init; }
+    public Dictionary<string, object>? Nbt { get; init; }
 }
 
 public sealed class MccInventorySnapshotResult
@@ -239,6 +240,7 @@ public sealed class MccInventorySearchMatch
     public required int Count { get; init; }
     public required bool IsPlayerInventory { get; init; }
     public int? HotbarSlot { get; init; }
+    public Dictionary<string, object>? Nbt { get; init; }
 }
 
 public sealed class MccInventorySearchResult


### PR DESCRIPTION
Right now the inventory tools only return item type and count, which makes it impossible to distinguish a renamed item from a plain one, read server-specific metadata (custom_data), or check enchantments and potion contents. The material name alone isn't enough for most real automation tasks.

This adds a nullable `Nbt` field to `MccInventorySnapshotSlot`, `MccInventorySearchMatch`, and `MccItemStackSnapshot`:

- On 1.20.6+ it's a map of component name -> serialized component, e.g. `"minecraft:custom_data"`, `"minecraft:enchantments"`, `"minecraft:custom_name"`
- On older versions it falls back to the raw NBT dictionary
- Omitted entirely when the item has no extra data (plain Stone, Dirt, etc. come back clean with no Nbt field)

To make this work, `StructuredComponent` now stores the registry name it was parsed under (`ComponentName`), set in `ParseComponent()` alongside the existing `TypeId`. Both are marked `[JsonIgnore]` so they don't appear in the serialized output. `BuildNbt` uses `c.GetType()` when calling `JsonSerializer.SerializeToElement` - necessary because the list elements are typed as the abstract base class and the default serializer would otherwise produce empty objects.

Tested against a 1.21.11 server with a mix of custom items (custom_data, enchantments, block_entity_data) and vanilla items.