### PR TITLE
fix: preserve queued disconnect reason

### DIFF
--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -304,7 +304,10 @@ namespace MinecraftClient.Protocol.Handlers
             {
                 Stopwatch stopWatch = Stopwatch.StartNew();
                 long nextUpdateDue = 0;
-                while (!packetQueue.IsAddingCompleted)
+                // Continue until the reader has finished and every queued packet has been handled.
+                // A server can close immediately after a Disconnect packet, completing the queue
+                // while that final packet is still waiting to be processed.
+                while (!packetQueue.IsCompleted)
                 {
                     cancelToken.ThrowIfCancellationRequested();
 


### PR DESCRIPTION
## Summary

`PacketReader` can finish immediately after queuing a server `Disconnect` packet. The updater previously stopped at that point, leaving the queued disconnect unread and reporting a generic connection loss.

The updater now runs until the queue is fully completed, so it processes packets that were already queued before reporting a transport failure.

## Testing

- `dotnet test MinecraftClient.Tests/MinecraftClient.Tests.csproj -c Release --no-restore --nologo --logger "console;verbosity=minimal" -v quiet` passed: 16 tests.
- Local offline 1.21.11 testing covered matching and nonmatching AutoRelog kicks, `Ignore_Kick_Message`, explicit logout, and a real socket loss through a disposable localhost proxy.
- A live run against `jogar.rederevo.com:25565` received Configuration `Disconnect` packet `0x02` and displayed the complete anti-bot verification message instead of `Connection has been lost.`

## Related issues

None.
