### PR TITLE
chore: update build dependencies

### DIFF
--- a/DebugTools/MccMcpStdioHarness/MccMcpStdioHarness.csproj
+++ b/DebugTools/MccMcpStdioHarness/MccMcpStdioHarness.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
+    <PackageReference Include="ModelContextProtocol" Version="1.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/DebugTools/MccMcpWebPlayground/MccMcpWebPlayground.csproj
+++ b/DebugTools/MccMcpWebPlayground/MccMcpWebPlayground.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
+    <PackageReference Include="ModelContextProtocol" Version="1.4.1" />
   </ItemGroup>
 
 </Project>

--- a/MinecraftClient.Tests/MinecraftClient.Tests.csproj
+++ b/MinecraftClient.Tests/MinecraftClient.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/MinecraftClient/MinecraftClient.csproj
+++ b/MinecraftClient/MinecraftClient.csproj
@@ -38,25 +38,25 @@
   <ItemGroup>
     <PackageReference Include="Brigadier.NET" Version="1.2.13" />
     <PackageReference Include="DiscordRichPresence" Version="1.143.0" />
-    <PackageReference Include="Consolonia" Version="11.3.12.3" />
+    <PackageReference Include="Consolonia" Version="11.3.12.6" />
     <PackageReference Include="DnsClient" Version="1.8.0" />
-    <PackageReference Include="DSharpPlus" Version="4.5.1" />
+    <PackageReference Include="DSharpPlus" Version="4.5.2" />
     <PackageReference Include="DynamicExpresso.Core" Version="2.19.3" />
     <PackageReference Include="FuzzySharp" Version="2.0.2" />
-    <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.11.1" />
-    <PackageReference Include="MessagePack" Version="3.1.4" />
-    <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
-    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageReference Include="Magick.NET-Q16-AnyCPU" Version="14.15.0" />
+    <PackageReference Include="MessagePack" Version="3.1.8" />
+    <PackageReference Include="ModelContextProtocol" Version="1.4.1" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.4.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="10.0.10" />
     <PackageReference Include="Samboy063.Tomlet" Version="6.2.0" />
-    <PackageReference Include="Sentry" Version="6.3.1" />
+    <PackageReference Include="Sentry" Version="6.8.0" />
     <PackageReference Include="SingleFileExtractor.Core" Version="2.3.0" />
 	<PackageReference Include="starksoft.aspen" Version="1.1.8">
 		<NoWarn>NU1701</NoWarn>
 	</PackageReference>
-    <PackageReference Include="Telegram.Bot" Version="22.9.5.3" />
+    <PackageReference Include="Telegram.Bot" Version="22.10.2.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="config\**\*.cs" />


### PR DESCRIPTION
## Summary

Update outdated build and runtime dependencies to eliminate NuGet vulnerability warnings and keep the .NET 10 solution current.

## Changes

- Update MCC runtime dependencies, including Magick.NET, MessagePack, Roslyn, MCP, Sentry, and Consolonia
- Update MCP debug-tool dependencies
- Update Microsoft.NET.Test.Sdk

## Files Changed

4 project files changed.

## Testing

- [x] `mcc-build-clean` followed by `mcc-build`: 0 warnings, 0 errors
- [x] Test suite: 31 passed, 0 failed
- [x] NuGet vulnerability audit, including transitive packages: no vulnerable packages
- [x] In-scope direct dependency audit: no updates remaining

## Related Issues

None