### PR TITLE
fix: accept semicolonless script using directives

### DIFF
--- a/MinecraftClient.Tests/CSharpRunnerTests.cs
+++ b/MinecraftClient.Tests/CSharpRunnerTests.cs
@@ -1,0 +1,14 @@
+using MinecraftClient.Scripting;
+
+namespace MinecraftClient.Tests;
+
+public sealed class CSharpRunnerTests
+{
+    [Theory]
+    [InlineData("//using MinecraftClient.CommandHandler", "using MinecraftClient.CommandHandler;")]
+    [InlineData("//using MinecraftClient.CommandHandler;", "using MinecraftClient.CommandHandler;")]
+    public void NormalizeUsingDirectiveAddsMissingSemicolon(string directive, string expected)
+    {
+        Assert.Equal(expected, CSharpRunner.NormalizeUsingDirective(directive));
+    }
+}

--- a/MinecraftClient/Scripting/CSharpRunner.cs
+++ b/MinecraftClient/Scripting/CSharpRunner.cs
@@ -60,7 +60,7 @@ namespace MinecraftClient.Scripting
                         string line = lines[i];
                         if (line.StartsWith("//using"))
                         {
-                            libs.Add(line.Replace("//", "").Trim());
+                            libs.Add(NormalizeUsingDirective(line));
                         }
                         else if (line.StartsWith("//dll"))
                         {
@@ -123,6 +123,12 @@ namespace MinecraftClient.Scripting
                 catch (Exception e) { throw new CSharpException(CSErrorType.RuntimeError, e); }
             }
             else return null;
+        }
+
+        internal static string NormalizeUsingDirective(string line)
+        {
+            string directive = line[2..].Trim();
+            return directive.EndsWith(';') ? directive : $"{directive};";
         }
 
         private static string BuildScriptCode(string scriptName, IEnumerable<ScriptSourceLine> script, IEnumerable<ScriptSourceLine> extensions, IEnumerable<string> libs, bool hasImplicitReturn)


### PR DESCRIPTION
## Summary

MCC copied `//using` metadata into generated C# without adding a semicolon. Scripts that followed the documented semicolonless form failed with `CS1002`, often on an unrelated source line.

This change adds the semicolon during preprocessing when it is missing. Directives that already include one are left unchanged.

## Changes

- Normalize standalone script `//using` directives before compilation.
- Cover both semicolonless and existing semicolon-terminated directives with regression tests.

## Testing

- `source tools/mcc-env.sh && mcc-build`
- `dotnet test MinecraftClient.Tests/MinecraftClient.Tests.csproj -c Release --no-build`: 38 passed
- Loaded a standalone script through `/script` on a local Minecraft 1.21.11 server in offline mode on port 25565.
  - Before the fix: compilation failed with `CS1002: ; expected` at line 13.
  - After the fix: compilation completed without errors and the bot logged `ISSUE_3195_PASS:CmdResult`.
  - The server log confirmed that the test client joined successfully.

## Related Issues

Fixes #3195
