### PR TITLE
fix: send dedicated attack packet on 26.1+

### DIFF
--- a/MinecraftClient/Protocol/Handlers/Protocol18.cs
+++ b/MinecraftClient/Protocol/Handlers/Protocol18.cs
@@ -5721,6 +5721,13 @@ namespace MinecraftClient.Protocol.Handlers
             {
                 List<byte> fields = new();
                 fields.AddRange(DataTypes.GetVarInt(EntityID));
+
+                if (protocolVersion >= MC_26_1_Version && type == (int)InteractType.Attack)
+                {
+                    SendPacket(PacketTypesOut.Attack, fields);
+                    return true;
+                }
+
                 fields.AddRange(DataTypes.GetVarInt(type));
 
                 // Is player Sneaking (Only 1.16 and above)


### PR DESCRIPTION
## Summary

Fix entity attacks on Minecraft 26.1 and newer by sending the dedicated serverbound Attack packet introduced in 26.1.

Previously, MCC continued encoding attacks as the legacy Interact packet. Purpur rejected that payload with `Failed to decode packet 'serverbound/minecraft:interact'` and disconnected the client.

## Changes

- Route 26.1+ attack interactions through `PacketTypesOut.Attack`
- Encode only the target entity ID, matching the 26.1+ server codec
- Preserve the legacy Interact packet format for Minecraft 1.21.11 and older

## Testing

- [x] Full solution build: 0 warnings, 0 errors
- [x] Test suite: 62 passed, 0 failed
- [x] Purpur 26.2, protocol 776: attack packet `0x01` accepted, zombie health reduced, MCC remained connected
- [x] Minecraft 26.1, protocol 775: attack packet `0x01` accepted, MCC remained connected
- [x] Minecraft 1.21.11, protocol 774: legacy Interact packet `0x19` retained and accepted

## Related Issues

Fixes #3198
